### PR TITLE
feat: add api route to connect backend

### DIFF
--- a/api/constant.js
+++ b/api/constant.js
@@ -1,0 +1,8 @@
+const NO_CACHE_HEADERS = {
+  'cache-control': 'no-cache, no-store, max-age=0, must-revalidate',
+  pragma: 'no-cache',
+}
+
+module.exports = {
+  NO_CACHE_HEADERS,
+}

--- a/api/headers.js
+++ b/api/headers.js
@@ -1,12 +1,9 @@
-const noCacheRule = {
-  'cache-control': 'no-cache, no-store, max-age=0, must-revalidate',
-  pragma: 'no-cache',
-}
+const { NO_CACHE_HEADERS } = require('./constant')
 
 module.exports = function (req, res, next) {
   const hostname = req.hostname
   if (hostname.match(/dev.mirrormedia.mg/gs)) {
-    res.set(noCacheRule)
+    res.set(NO_CACHE_HEADERS)
     return next()
   }
 
@@ -16,9 +13,9 @@ module.exports = function (req, res, next) {
         /^\/$|^\/(section|category|topic|externals|search|author|tag)\//gs
       )
     ) {
-      res.set(noCacheRule)
+      res.set(NO_CACHE_HEADERS)
     }
-    if (req.url.match(/^\/(story|app)\//gs)) {
+    if (req.url.match(/^\/(api|story|app)\//gs)) {
       res.set('cache-control', 'public, max-age=600')
     }
     return next()

--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,29 @@
+const axios = require('axios')
+
+const {
+  API_HOST,
+  API_PORT,
+  API_PROTOCOL,
+  API_TIMEOUT,
+} = require('../configs/config')
+const { NO_CACHE_HEADERS } = require('./constant')
+
+module.exports = async function (req, res, next) {
+  try {
+    const response = await axios({
+      method: req.method,
+      url: `${API_PROTOCOL}://${API_HOST}:${API_PORT}${req.url}`,
+      data: req.method === 'GET' ? undefined : req.body,
+      timeout: API_TIMEOUT,
+    })
+
+    if (response.data._status === 'ERR') {
+      res.set(NO_CACHE_HEADERS)
+    }
+    res.send(response.data)
+  } catch (error) {
+    res.set(NO_CACHE_HEADERS)
+    res.status(500).send(error.message)
+    console.error(`[API] url: ${req.url}`, error)
+  }
+}

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -34,7 +34,10 @@ module.exports = {
   /*
    ** Nuxt.js Server Middleware
    */
-  serverMiddleware: ['~/api/headers.js'],
+  serverMiddleware: [
+    '~/api/headers.js',
+    { path: '/api', handler: '~/api/index.js' },
+  ],
   /*
    ** Nuxt.js dev-modules
    */

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
   "dependencies": {
     "@nuxtjs/axios": "^5.3.6",
     "@nuxtjs/google-analytics": "^2.2.3",
+    "axios": "^0.19.2",
+    "body-parser": "^1.19.0",
     "cross-env": "^7.0.2",
     "express": "^4.16.4",
     "helmet": "^3.22.0",

--- a/server/index.js
+++ b/server/index.js
@@ -1,4 +1,5 @@
 const express = require('express')
+const bodyParser = require('body-parser')
 const consola = require('consola')
 const { Nuxt, Builder } = require('nuxt')
 const app = express()
@@ -23,6 +24,8 @@ async function start() {
   }
 
   app.use(helmet())
+
+  app.use(bodyParser.json())
 
   // Give nuxt middleware to express
   app.use(nuxt.render)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2290,7 +2290,7 @@ bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
   integrity sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==
 
-body-parser@1.19.0:
+body-parser@1.19.0, body-parser@^1.19.0:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.0.tgz#96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
   integrity sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==


### PR DESCRIPTION
- 串 tr-project-rest API
- 設定 `/api` 的 cache-control
- 將共用的 header 規則移到 `api/constant.js` (檔案名稱可討論)

需新增 config 請留意 slack 訊息或看 paper 文件