### PR TITLE
feat: add request plugin

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -30,6 +30,7 @@ module.exports = {
   plugins: [
     '~/plugins/vuePluginsGlobal.js',
     '~/plugins/vueDirectivesGlobal.js',
+    '~/plugins/requests/index.js',
   ],
   /*
    ** Nuxt.js Server Middleware

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "humps": "^2.0.1",
     "lodash": "^4.17.15",
     "nuxt": "^2.12.2",
+    "qs": "^6.9.4",
     "vue-infinite-loading": "^2.4.5",
     "vue-lazyload": "^1.3.3"
   },

--- a/plugins/requests/__tests__/index.spec.js
+++ b/plugins/requests/__tests__/index.spec.js
@@ -1,0 +1,63 @@
+import { buildParams } from '../index'
+
+describe('buildParams function', () => {
+  test('should return empty string', () => {
+    expect(buildParams()).toBe('')
+    expect(buildParams([])).toBe('')
+    expect(buildParams({})).toBe('')
+    expect(buildParams(1234)).toBe('')
+    expect(buildParams('string')).toBe('')
+    expect(buildParams(null)).toBe('')
+    expect(buildParams(undefined)).toBe('')
+  })
+
+  test('should return correct string', () => {
+    expect(
+      buildParams({ page: 1, sort: '-publishedDate', maxResults: 10 })
+    ).toBe('?page=1&sort=-publishedDate&max_results=10')
+
+    expect(
+      buildParams({
+        slug: '20180125pol010',
+        isAudioSiteOnly: false,
+        clean: 'content',
+      })
+    ).toBe(
+      '?where=%7B%22slug%22%3A%2220180125pol010%22%2C%22isAudioSiteOnly%22%3Afalse%7D&clean=content'
+    )
+
+    expect(
+      buildParams({
+        page: 1,
+        categories: ['5979ac0de531830d00e330a7', '5979ac33e531830d00e330a9'],
+        isAudioSiteOnly: false,
+        maxResults: 10,
+      })
+    ).toBe(
+      '?page=1&where=%7B%22categories%22%3A%7B%22%24in%22%3A%5B%225979ac0de531830d00e330a7%22%2C%225979ac33e531830d00e330a9%22%5D%7D%2C%22isAudioSiteOnly%22%3Afalse%7D&max_results=10'
+    )
+
+    expect(buildParams({ id: '584fb40ab854000d002d23cb' })).toBe(
+      '?where=%7B%22_id%22%3A%22584fb40ab854000d002d23cb%22%7D'
+    )
+
+    expect(
+      buildParams({
+        $or: [
+          {
+            writers: '584fb40ab854000d002d23cb',
+            photographers: '584fb40ab854000d002d23cb',
+          },
+        ],
+        maxResults: 10,
+      })
+    ).toBe(
+      '?where=%7B%22%24or%22%3A%5B%7B%22writers%22%3A%22584fb40ab854000d002d23cb%22%2C%22photographers%22%3A%22584fb40ab854000d002d23cb%22%7D%5D%7D&max_results=10'
+    )
+
+    expect(buildParams({ endpoint: 'sections' })).toBe('?endpoint=sections')
+    expect(buildParams({ endpoint: ['sections', 'topics'] })).toBe(
+      '?endpoint=sections&endpoint=topics'
+    )
+  })
+})

--- a/plugins/requests/index.js
+++ b/plugins/requests/index.js
@@ -35,7 +35,7 @@ async function axiosGet(url) {
 }
 
 export function buildParams(params = {}) {
-  const isPureObject = _.isObject(params) && !_.isArray(params)
+  const isPureObject = _.isObject(params) && !Array.isArray(params)
   const firstTier = [
     'endpoint',
     'maxResults',
@@ -66,7 +66,7 @@ export function buildParams(params = {}) {
         _.set(queryParams, 'where.$or', params[param])
       } else if (param === 'id') {
         _.set(queryParams, 'where._id', params[param])
-      } else if (_.isArray(params[param])) {
+      } else if (Array.isArray(params[param])) {
         _.set(queryParams, `where.${snakeCase(param)}.$in`, params[param])
       } else {
         _.set(queryParams, `where.${snakeCase(param)}`, params[param])

--- a/plugins/requests/index.js
+++ b/plugins/requests/index.js
@@ -1,0 +1,124 @@
+import { camelizeKeys } from 'humps'
+import _ from 'lodash'
+import axios from 'axios'
+import qs from 'qs'
+
+function snakeCase(text) {
+  return text === 'isAudioSiteOnly' ? text : _.snakeCase(text)
+}
+
+async function axiosGet(url) {
+  try {
+    const baseUrl = process.browser
+      ? `//${location.host}/`
+      : process.env._AXIOS_BASE_URL_
+    const res = await axios.get(`${baseUrl}api${url}`)
+    const data = camelizeKeys(res.data)
+    const hasData =
+      (data.items && data.items.length > 0) ||
+      (data.endpoints && Object.keys(data.endpoints).length > 0)
+
+    if (hasData) {
+      return data
+    }
+
+    const e = new Error()
+    e.massage = 'Not Found'
+    e.code = '404'
+    throw e
+  } catch (error) {
+    const e = new Error()
+    e.massage = error.massage || error
+    e.code = error.code || '500'
+    throw e
+  }
+}
+
+export function buildParams(params = {}) {
+  const isPureObject = _.isObject(params) && !_.isArray(params)
+  const firstTier = [
+    'endpoint',
+    'maxResults',
+    'page',
+    'sort',
+    'clean',
+    'related',
+    'keyword',
+  ]
+
+  if (isPureObject && Object.keys(params).length > 0) {
+    const paramsKey = Object.keys(params)
+
+    if (paramsKey.includes('endpoint')) {
+      return _.isArray(params.endpoint)
+        ? `?${params.endpoint
+            .map((endpoint) => `endpoint=${endpoint}`)
+            .join('&')}`
+        : `?endpoint=${params.endpoint}`
+    }
+
+    const queryParams = {}
+
+    paramsKey.forEach((param) => {
+      if (firstTier.some((key) => key === param)) {
+        queryParams[snakeCase(param)] = params[param]
+      } else if (param === '$or') {
+        _.set(queryParams, 'where.$or', params[param])
+      } else if (param === 'id') {
+        _.set(queryParams, 'where._id', params[param])
+      } else if (_.isArray(params[param])) {
+        _.set(queryParams, `where.${snakeCase(param)}.$in`, params[param])
+      } else {
+        _.set(queryParams, `where.${snakeCase(param)}`, params[param])
+      }
+    })
+
+    if (queryParams.where) {
+      queryParams.where = JSON.stringify(queryParams.where)
+    }
+    return `?${qs.stringify(queryParams)}`
+  }
+  return ''
+}
+
+export default ({ app }, inject) => {
+  inject('fetchActivities', (params) =>
+    axiosGet(`/activities${buildParams(params)}`)
+  )
+
+  inject('fetchCombo', (params) => axiosGet(`/combo${buildParams(params)}`))
+
+  inject('fetchContacts', (params) =>
+    axiosGet(`/contacts${buildParams(params)}`)
+  )
+
+  inject('fetchEvent', (params) => axiosGet(`/event${buildParams(params)}`))
+
+  inject('fetchExternals', (params) =>
+    axiosGet(`/externals${buildParams(params)}`)
+  )
+
+  inject('fetchImages', (params) => axiosGet(`/images${buildParams(params)}`))
+
+  inject('fetchList', (params) => axiosGet(`/getlist${buildParams(params)}`))
+
+  inject('fetchNodes', (params) => axiosGet(`/nodes${buildParams(params)}`))
+
+  inject('fetchPartners', (params) =>
+    axiosGet(`/partners${buildParams(params)}`)
+  )
+
+  inject('fetchPoplist', () => axiosGet(`/poplist`))
+
+  inject('fetchPosts', (params) => axiosGet(`/getposts${buildParams(params)}`))
+
+  inject('fetchSearch', (params) => axiosGet(`/search${buildParams(params)}`))
+
+  inject('fetchTag', (id) => axiosGet(`/tags/${id}`))
+
+  inject('fetchTimeline', (id) => axiosGet(`/timeline/${id}`))
+
+  inject('fetchTopics', (params) => axiosGet(`/topics${buildParams(params)}`))
+
+  inject('fetchWatches', (params) => axiosGet(`/watches${buildParams(params)}`))
+}

--- a/plugins/requests/index.js
+++ b/plugins/requests/index.js
@@ -63,8 +63,10 @@ export function buildParams(params = {}) {
       if (firstTier.some((key) => key === param)) {
         queryParams[snakeCase(param)] = params[param]
       } else if (param === '$or') {
+        // handle _.snakeCase filter $ character
         _.set(queryParams, 'where.$or', params[param])
       } else if (param === 'id') {
+        // handle id need convert to tr-project-rest format _id
         _.set(queryParams, 'where._id', params[param])
       } else if (Array.isArray(params[param])) {
         _.set(queryParams, `where.${snakeCase(param)}.$in`, params[param])

--- a/plugins/requests/index.js
+++ b/plugins/requests/index.js
@@ -4,7 +4,10 @@ import axios from 'axios'
 import qs from 'qs'
 
 function snakeCase(text) {
-  return text === 'isAudioSiteOnly' ? text : _.snakeCase(text)
+  if (text === 'isAudioSiteOnly') {
+    return text
+  }
+  return _.snakeCase(text)
 }
 
 async function axiosGet(url) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8962,6 +8962,11 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
+qs@^6.9.4:
+  version "6.9.4"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.4.tgz#9090b290d1f91728d3c22e54843ca44aea5ab687"
+  integrity sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==
+
 qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"


### PR DESCRIPTION
Resolve #41 

用法基本上根據討論結果來實作

- 討論當時沒有注意到的狀況：在 `where` 下使用 `$or` 的用法

`/getposts?where={"$or":[{"writers":"584fb40ab854000d002d23cb"},{"photographers":"584fb40ab854000d002d23cb"},{"camera_man":"584fb40ab854000d002d23cb"},{"designers":"584fb40ab854000d002d23cb"},{"engineers":"584fb40ab854000d002d23cb"}]}`

  因此有針對 `$or` 做特別處理，用法可以參考測試

- 由於 tr-project-rest 的風格不一致，因此有特別處理 `isAudioSiteOnly`
- 考量 `snakeCase`, `axiosGet`, `buildParams` 只會在這裡有使用需求，就沒有另外分到其他檔案
- 注意 `fetchTag`, `fetchTimeline` 的使用狀況跟其他不一樣，接受的參數是 `id`，可以參考 API 使用文件

使用範例：
```
async fetch() {
  try {
    const xxx = await this.$fetchCombo({ endpoint: 'sections' })
  } catch (error) {
    // error.code 判斷 404 還是 500
  }
}

```
```
// promise version
mounted () {
  this.$fetchCombo({ endpoint: 'sections' })
    .then((res) => {
       // to do
    })
    .catch(error => {
      // handle error
    })
}
