### PR TITLE
refactor: section colors

### DIFF
--- a/components/UIHeaderNavSection.vue
+++ b/components/UIHeaderNavSection.vue
@@ -83,20 +83,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-$sections-color: (
-  'news': #30bac8,
-  'entertainment': #bf3284,
-  'businessmoney': #009045,
-  'people': #efa256,
-  'videohub': #969696,
-  'international': #911f27,
-  'foodtravel': #eac151,
-  'mafalda': #662d8e,
-  'culture': #009245,
-  'carandwatch': #003153,
-  'external': #ee5a24,
-);
-
 .header-nav-section {
   font-size: 14px;
   // to hide scrollbar

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -10,3 +10,23 @@ $grid-breakpoints: (
   xl: 1200px,
   xxl: 1400px
 ) !default;
+
+$sections-color: (
+  news: #30bac8,
+  entertainment: #bf3284,
+  businessmoney: #009045,
+  people: #efa256,
+  videohub: #969696,
+  international: #911f27,
+  foodtravel: #eac151,
+  mafalda: #662d8e,
+  culture: #009245,
+  carandwatch: #003153,
+  external: #ee5a24,
+);
+
+:export {
+  @each $key, $value in $sections-color {
+    sections-color-#{$key}: $value;
+  }
+}


### PR DESCRIPTION
1. 將 `$sections-color` 加入至 `scss/_variables.scss`，使得各 component 中的 scss style 可以共用。
2. 新增 `:export` 於 `scss/_variables.scss`，使得 js 可以 import 並利用，但由於應該是無法直接 export scss map 給 js 使用，所以需要將其分解，js 中的使用方式請參考：
```js
import variables from '~/scss/_variables.scss'

console.log(variables)
// {
//   sections-color-businessmoney: "#009045",
//   sections-color-carandwatch: "#003153",
//   sections-color-culture: "#009245",
//   sections-color-entertainment: "#bf3284",
//   sections-color-external: "#ee5a24",
//   sections-color-foodtravel: "#eac151",
//   sections-color-international: "#911f27",
//   sections-color-mafalda: "#662d8e",
//   sections-color-news: "#30bac8",
//   sections-color-people: "#efa256",
//   sections-color-videohub: "#969696",
// }
```