### PR TITLE
feat: add listing category and author page

### DIFF
--- a/components/UIInfiniteLoading.vue
+++ b/components/UIInfiniteLoading.vue
@@ -1,0 +1,36 @@
+<template>
+  <client-only>
+    <infinite-loading @infinite="infiniteHandler">
+      <UILoadmoreLoadingIcon slot="spinner" class="spinner" />
+      <!-- provide empty slot if we want to disable load messages locally -->
+      <!-- see: https://peachscript.github.io/vue-infinite-loading/guide/configure-load-msg.html#via-slot-sepcial-attribute -->
+      <div slot="no-more" />
+      <div slot="no-results" />
+      <div slot="error" />
+    </infinite-loading>
+  </client-only>
+</template>
+
+<script>
+import InfiniteLoading from 'vue-infinite-loading'
+import UILoadmoreLoadingIcon from '~/components/UILoadmoreLoadingIcon.vue'
+
+export default {
+  name: 'UIInfiniteLoading',
+  components: {
+    InfiniteLoading,
+    UILoadmoreLoadingIcon,
+  },
+  methods: {
+    infiniteHandler($state) {
+      this.$emit('infinite', $state)
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.spinner {
+  margin: 20px 0 0 0;
+}
+</style>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -33,7 +33,7 @@ export default {
   },
   computed: {
     isListing() {
-      const listingRouteNames = ['section-name']
+      const listingRouteNames = ['section-name', 'category-name']
       return listingRouteNames.includes(this.$route.name)
     },
   },

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -33,7 +33,7 @@ export default {
   },
   computed: {
     isListing() {
-      const listingRouteNames = ['section-name', 'category-name']
+      const listingRouteNames = ['section-name', 'category-name', 'author-id']
       return listingRouteNames.includes(this.$route.name)
     },
   },

--- a/pages/__tests__/author.spec.js
+++ b/pages/__tests__/author.spec.js
@@ -1,0 +1,117 @@
+import page from '../author/_id.vue'
+import UIArticleList from '~/components/UIArticleList.vue'
+import createWrapperHelper from '~/test/helpers/createWrapperHelper'
+
+const createWrapper = createWrapperHelper({
+  mocks: {
+    $route: {
+      params: {
+        name: '',
+      },
+    },
+    $store: {
+      state: {
+        sections: {
+          data: {
+            items: [],
+          },
+        },
+      },
+    },
+  },
+  stubs: ['client-only'],
+})
+
+describe('stripHtmlTag method', () => {
+  test('should strip html tags successfully', () => {
+    const wrapper = createWrapper(page)
+    const html = '<div><script></script><p>foo</p><p>bar</p><p>123</p></div>'
+    expect(wrapper.vm.stripHtmlTag(html)).toBe('foobar123')
+  })
+  test('should return the same result if there is not html tags', () => {
+    const wrapper = createWrapper(page)
+    const html = 'foobar123'
+    expect(wrapper.vm.stripHtmlTag(html)).toBe('foobar123')
+  })
+})
+
+describe('component methods', () => {
+  test('setListData', () => {
+    const idMock = 'id'
+    const slugMock = 'slug'
+    const imageUrlMock = 'imageurl'
+    const titleMock = 'title'
+    const briefMock = 'brief'
+    const briefHtmlMock = `<div>${briefMock}</div>`
+    const sectionTitleMock = 'section-title'
+    const responseMock = {
+      items: [
+        {
+          id: idMock,
+          slug: slugMock,
+          heroImage: {
+            image: {
+              resizedTargets: {
+                mobile: {
+                  url: imageUrlMock,
+                },
+              },
+            },
+          },
+          title: titleMock,
+          brief: {
+            html: briefHtmlMock,
+          },
+          sections: [
+            {
+              title: sectionTitleMock,
+            },
+          ],
+        },
+      ],
+    }
+
+    const wrapper = createWrapper(page)
+    wrapper.vm.setListData(responseMock)
+    const list = wrapper.find(UIArticleList)
+    expect(list.props().listData).toEqual([
+      {
+        id: idMock,
+        href: `/story/${slugMock}`,
+        imgSrc: imageUrlMock,
+        imgText: sectionTitleMock,
+        imgTextBackgroundColor: undefined, // value from scss variable not available in jest
+        infoTitle: titleMock,
+        infoDescription: briefMock,
+      },
+    ])
+  })
+  test('setListDataTotal and listDataPageLimit computed by total', () => {
+    const totalMock = 1234
+    const responseMock = {
+      meta: {
+        total: totalMock,
+      },
+    }
+    const wrapper = createWrapper(page)
+    wrapper.vm.setListDataTotal(responseMock)
+    expect(wrapper.vm.listDataTotal).toBe(totalMock)
+    expect(wrapper.vm.listDataPageLimit).toBe(
+      Math.ceil(totalMock / wrapper.vm.listDataMaxResults)
+    )
+  })
+  test('setAuthorName', () => {
+    const authorNameMock = 'name'
+    const responseMock = {
+      items: [
+        {
+          name: authorNameMock,
+        },
+      ],
+    }
+
+    const wrapper = createWrapper(page)
+    wrapper.vm.setAuthorName(responseMock)
+    expect(wrapper.vm.authorName).toBe(authorNameMock)
+  })
+})

--- a/pages/__tests__/category.spec.js
+++ b/pages/__tests__/category.spec.js
@@ -1,0 +1,212 @@
+import page from '../category/_name.vue'
+import createWrapperHelper from '~/test/helpers/createWrapperHelper'
+
+const createWrapper = createWrapperHelper({
+  mocks: {
+    $route: {
+      params: {
+        name: '',
+      },
+    },
+    $store: {
+      state: {
+        sections: {
+          data: {
+            items: [],
+          },
+        },
+      },
+    },
+  },
+  stubs: ['client-only'],
+})
+
+describe('stripHtmlTag method', () => {
+  test('should strip html tags successfully', () => {
+    const wrapper = createWrapper(page)
+    const html = '<div><script></script><p>foo</p><p>bar</p><p>123</p></div>'
+    expect(wrapper.vm.stripHtmlTag(html)).toBe('foobar123')
+  })
+  test('should return the same result if there is not html tags', () => {
+    const wrapper = createWrapper(page)
+    const html = 'foobar123'
+    expect(wrapper.vm.stripHtmlTag(html)).toBe('foobar123')
+  })
+})
+
+describe('section data', () => {
+  test('should get proper section properties from store by route params', () => {
+    const categoryNameMock = 'test-category-name'
+    const sectionNameMock = 'test-name'
+    const sectionIdMock = 'test-id'
+    const sectionTitleMock = 'test-title'
+    const sectionStoreMock = {
+      data: {
+        items: [
+          {
+            categories: [
+              {
+                name: categoryNameMock,
+              },
+            ],
+            name: sectionNameMock,
+            id: sectionIdMock,
+            title: sectionTitleMock,
+          },
+        ],
+      },
+    }
+    const wrapper = createWrapper(page, {
+      mocks: {
+        $route: {
+          params: {
+            name: categoryNameMock,
+          },
+        },
+        $store: {
+          state: {
+            sections: sectionStoreMock,
+          },
+        },
+      },
+    })
+    expect(wrapper.vm.currentSectionName).toBe(sectionNameMock)
+    expect(wrapper.vm.currentSectionId).toBe(sectionIdMock)
+    expect(wrapper.vm.currentSectionTitle).toBe(sectionTitleMock)
+  })
+})
+
+describe('category data', () => {
+  test('should get proper categories properties from store by route params', () => {
+    const categoryNameMock = 'test-category-name'
+    const categoryIdMock = 'test-id'
+    const categoryTitleMock = 'test-title'
+    const sectionStoreMock = {
+      data: {
+        items: [
+          {
+            categories: [
+              {
+                name: categoryNameMock,
+                id: categoryIdMock,
+                title: categoryTitleMock,
+              },
+            ],
+          },
+        ],
+      },
+    }
+    const wrapper = createWrapper(page, {
+      mocks: {
+        $route: {
+          params: {
+            name: categoryNameMock,
+          },
+        },
+        $store: {
+          state: {
+            sections: sectionStoreMock,
+          },
+        },
+      },
+    })
+    expect(wrapper.vm.currentCategoryId).toBe(categoryIdMock)
+    expect(wrapper.vm.currentCategoryTitle).toBe(categoryTitleMock)
+  })
+})
+
+describe('component methods', () => {
+  test('setListData', () => {
+    const categoryNameMock = 'test-category-name'
+    const sectionNameMock = 'test-name'
+    const sectionIdMock = 'test-id'
+    const sectionTitleMock = 'test-title'
+    const sectionStoreMock = {
+      data: {
+        items: [
+          {
+            categories: [
+              {
+                name: categoryNameMock,
+              },
+            ],
+            name: sectionNameMock,
+            id: sectionIdMock,
+            title: sectionTitleMock,
+          },
+        ],
+      },
+    }
+
+    const idMock = 'id'
+    const slugMock = 'slug'
+    const imageUrlMock = 'imageurl'
+    const titleMock = 'title'
+    const briefMock = 'brief'
+    const briefHtmlMock = `<div>${briefMock}</div>`
+    const responseMock = {
+      items: [
+        {
+          name: sectionNameMock,
+          id: idMock,
+          slug: slugMock,
+          heroImage: {
+            image: {
+              resizedTargets: {
+                mobile: {
+                  url: imageUrlMock,
+                },
+              },
+            },
+          },
+          title: titleMock,
+          brief: {
+            html: briefHtmlMock,
+          },
+        },
+      ],
+    }
+
+    const wrapper = createWrapper(page, {
+      mocks: {
+        $route: {
+          params: {
+            name: categoryNameMock,
+          },
+        },
+        $store: {
+          state: {
+            sections: sectionStoreMock,
+          },
+        },
+      },
+    })
+
+    wrapper.vm.setListData(responseMock)
+    expect(wrapper.vm.listData).toEqual([
+      {
+        id: idMock,
+        href: `/story/${slugMock}`,
+        imgSrc: imageUrlMock,
+        imgText: sectionTitleMock,
+        imgTextBackgroundColor: undefined, // value from scss variable not available in jest
+        infoTitle: titleMock,
+        infoDescription: briefMock,
+      },
+    ])
+  })
+  test('setListDataTotal and listDataPageLimit computed by total', () => {
+    const totalMock = 1234
+    const responseMock = {
+      meta: {
+        total: totalMock,
+      },
+    }
+    const wrapper = createWrapper(page)
+    wrapper.vm.setListDataTotal(responseMock)
+    expect(wrapper.vm.listDataTotal).toBe(totalMock)
+    expect(wrapper.vm.listDataPageLimit).toBe(
+      Math.ceil(totalMock / wrapper.vm.listDataMaxResults)
+    )
+  })
+})

--- a/pages/__tests__/category.spec.js
+++ b/pages/__tests__/category.spec.js
@@ -1,4 +1,5 @@
 import page from '../category/_name.vue'
+import UIArticleList from '~/components/UIArticleList.vue'
 import createWrapperHelper from '~/test/helpers/createWrapperHelper'
 
 const createWrapper = createWrapperHelper({
@@ -110,8 +111,9 @@ describe('category data', () => {
         },
       },
     })
+    const list = wrapper.find(UIArticleList)
     expect(wrapper.vm.currentCategoryId).toBe(categoryIdMock)
-    expect(wrapper.vm.currentCategoryTitle).toBe(categoryTitleMock)
+    expect(list.props().listTitle).toBe(categoryTitleMock)
   })
 })
 
@@ -183,7 +185,8 @@ describe('component methods', () => {
     })
 
     wrapper.vm.setListData(responseMock)
-    expect(wrapper.vm.listData).toEqual([
+    const list = wrapper.find(UIArticleList)
+    expect(list.props().listData).toEqual([
       {
         id: idMock,
         href: `/story/${slugMock}`,

--- a/pages/__tests__/section.spec.js
+++ b/pages/__tests__/section.spec.js
@@ -68,3 +68,93 @@ describe('section data', () => {
     expect(wrapper.vm.currentSectionTitle).toBe(sectionTitleMock)
   })
 })
+
+describe('component methods', () => {
+  test('setListData', () => {
+    const sectionNameMock = 'test-name'
+    const sectionIdMock = 'test-id'
+    const sectionTitleMock = 'test-title'
+    const sectionStoreMock = {
+      data: {
+        items: [
+          {
+            name: sectionNameMock,
+            id: sectionIdMock,
+            title: sectionTitleMock,
+          },
+        ],
+      },
+    }
+
+    const idMock = 'id'
+    const slugMock = 'slug'
+    const imageUrlMock = 'imageurl'
+    const titleMock = 'title'
+    const briefMock = 'brief'
+    const briefHtmlMock = `<div>${briefMock}</div>`
+    const responseMock = {
+      items: [
+        {
+          name: sectionNameMock,
+          id: idMock,
+          slug: slugMock,
+          heroImage: {
+            image: {
+              resizedTargets: {
+                mobile: {
+                  url: imageUrlMock,
+                },
+              },
+            },
+          },
+          title: titleMock,
+          brief: {
+            html: briefHtmlMock,
+          },
+        },
+      ],
+    }
+
+    const wrapper = createWrapper(page, {
+      mocks: {
+        $route: {
+          params: {
+            name: sectionNameMock,
+          },
+        },
+        $store: {
+          state: {
+            sections: sectionStoreMock,
+          },
+        },
+      },
+    })
+
+    wrapper.vm.setListData(responseMock)
+    expect(wrapper.vm.listData).toEqual([
+      {
+        id: idMock,
+        href: `/story/${slugMock}`,
+        imgSrc: imageUrlMock,
+        imgText: sectionTitleMock,
+        imgTextBackgroundColor: undefined, // value from scss variable not available in jest
+        infoTitle: titleMock,
+        infoDescription: briefMock,
+      },
+    ])
+  })
+  test('setListDataTotal and listDataPageLimit computed by total', () => {
+    const totalMock = 1234
+    const responseMock = {
+      meta: {
+        total: totalMock,
+      },
+    }
+    const wrapper = createWrapper(page)
+    wrapper.vm.setListDataTotal(responseMock)
+    expect(wrapper.vm.listDataTotal).toBe(totalMock)
+    expect(wrapper.vm.listDataPageLimit).toBe(
+      Math.ceil(totalMock / wrapper.vm.listDataMaxResults)
+    )
+  })
+})

--- a/pages/__tests__/section.spec.js
+++ b/pages/__tests__/section.spec.js
@@ -1,4 +1,5 @@
 import page from '../section/_name.vue'
+import UIArticleList from '~/components/UIArticleList.vue'
 import createWrapperHelper from '~/test/helpers/createWrapperHelper'
 
 const createWrapper = createWrapperHelper({
@@ -64,8 +65,9 @@ describe('section data', () => {
         },
       },
     })
+    const list = wrapper.find(UIArticleList)
     expect(wrapper.vm.currentSectionId).toBe(sectionIdMock)
-    expect(wrapper.vm.currentSectionTitle).toBe(sectionTitleMock)
+    expect(list.props().listTitle).toBe(sectionTitleMock)
   })
 })
 
@@ -131,7 +133,8 @@ describe('component methods', () => {
     })
 
     wrapper.vm.setListData(responseMock)
-    expect(wrapper.vm.listData).toEqual([
+    const list = wrapper.find(UIArticleList)
+    expect(list.props().listData).toEqual([
       {
         id: idMock,
         href: `/story/${slugMock}`,

--- a/pages/author/_id.vue
+++ b/pages/author/_id.vue
@@ -6,34 +6,23 @@
       :listTitleColor="'#BCBCBC'"
       :listData="listData"
     />
-    <client-only>
-      <infinite-loading
-        v-if="shouldMountInfiniteLoading"
-        @infinite="infiniteHandler"
-      >
-        <UILoadmoreLoadingIcon slot="spinner" class="spinner" />
-        <!-- provide empty slot if we want to disable load messages locally -->
-        <!-- see: https://peachscript.github.io/vue-infinite-loading/guide/configure-load-msg.html#via-slot-sepcial-attribute -->
-        <div slot="no-more" />
-        <div slot="no-results" />
-        <div slot="error" />
-      </infinite-loading>
-    </client-only>
+    <UIInfiniteLoading
+      v-if="shouldMountInfiniteLoading"
+      @infinite="infiniteHandler"
+    />
   </section>
 </template>
 
 <script>
-import InfiniteLoading from 'vue-infinite-loading'
-import UILoadmoreLoadingIcon from '~/components/UILoadmoreLoadingIcon.vue'
 import UIArticleList from '~/components/UIArticleList.vue'
+import UIInfiniteLoading from '~/components/UIInfiniteLoading.vue'
 import styleVariables from '~/scss/_variables.scss'
 
 export default {
   name: 'Author',
   components: {
-    InfiniteLoading,
-    UILoadmoreLoadingIcon,
     UIArticleList,
+    UIInfiniteLoading,
   },
   async fetch() {
     const response = await this.fetchAuthorListing({ page: 1 })
@@ -159,9 +148,5 @@ export default {
       margin: 8px 0 0 0;
     }
   }
-}
-
-.spinner {
-  margin: 20px 0 0 0;
 }
 </style>

--- a/pages/author/_id.vue
+++ b/pages/author/_id.vue
@@ -1,0 +1,167 @@
+<template>
+  <section class="section">
+    <UIArticleList
+      class="section__list"
+      :listTitle="authorName"
+      :listTitleColor="'#BCBCBC'"
+      :listData="listData"
+    />
+    <client-only>
+      <infinite-loading
+        v-if="shouldMountInfiniteLoading"
+        @infinite="infiniteHandler"
+      >
+        <UILoadmoreLoadingIcon slot="spinner" class="spinner" />
+        <!-- provide empty slot if we want to disable load messages locally -->
+        <!-- see: https://peachscript.github.io/vue-infinite-loading/guide/configure-load-msg.html#via-slot-sepcial-attribute -->
+        <div slot="no-more" />
+        <div slot="no-results" />
+        <div slot="error" />
+      </infinite-loading>
+    </client-only>
+  </section>
+</template>
+
+<script>
+import InfiniteLoading from 'vue-infinite-loading'
+import UILoadmoreLoadingIcon from '~/components/UILoadmoreLoadingIcon.vue'
+import UIArticleList from '~/components/UIArticleList.vue'
+import styleVariables from '~/scss/_variables.scss'
+
+export default {
+  name: 'Author',
+  components: {
+    InfiniteLoading,
+    UILoadmoreLoadingIcon,
+    UIArticleList,
+  },
+  async fetch() {
+    const response = await this.fetchAuthorListing({ page: 1 })
+    this.setListData(response)
+    this.setListDataTotal(response)
+    this.listDataCurrentPage += 1
+
+    const responseAuthor = await this.fetchAuthor()
+    this.setAuthorName(responseAuthor)
+  },
+  data() {
+    return {
+      listData: [],
+      listDataCurrentPage: 0,
+      listDataMaxResults: 9,
+      listDataTotal: undefined,
+      authorName: undefined,
+    }
+  },
+  computed: {
+    currentAuthorId() {
+      return this.$route.params.id
+    },
+
+    listDataPageLimit() {
+      if (this.listDataTotal === undefined) {
+        return undefined
+      }
+      return Math.ceil(this.listDataTotal / this.listDataMaxResults)
+    },
+
+    // Constraint which prevent loadmore unexpectly
+    // if we navigating on client-side
+    // due to the list data of the first page has not been loaded.
+    shouldMountInfiniteLoading() {
+      return this.listDataCurrentPage >= 1
+    },
+  },
+  methods: {
+    stripHtmlTag(html = '') {
+      return html.replace(/<\/?[^>]+(>|$)/g, '')
+    },
+    mapDataToComponentProps(item) {
+      const section = (item.sections ?? [])[0]
+      return {
+        id: item.id,
+        href: item.slug ? `/story/${item.slug}` : '/',
+        imgSrc: item.heroImage?.image?.resizedTargets?.mobile?.url ?? '',
+        imgText: section.title ?? '',
+        imgTextBackgroundColor:
+          styleVariables[`sections-color-${section.name}`],
+        infoTitle: item.title ?? '',
+        infoDescription: this.stripHtmlTag(item.brief?.html ?? ''),
+      }
+    },
+    async fetchAuthor() {
+      const response = await this.$fetchContacts({
+        id: this.currentAuthorId,
+      })
+      return response
+    },
+    setAuthorName(response = {}) {
+      this.authorName = (response.items ?? [])[0]?.name
+    },
+    async fetchAuthorListing({ page = 1 }) {
+      const response = await this.$fetchPosts({
+        maxResults: this.listDataMaxResults,
+        sort: '-publishedDate',
+        $or: [
+          { writers: this.currentAuthorId },
+          { photographers: this.currentAuthorId },
+          { camera_man: this.currentAuthorId },
+          { designers: this.currentAuthorId },
+          { engineers: this.currentAuthorId },
+        ],
+        page,
+      })
+      return response
+    },
+    setListData(response = {}) {
+      let listData = response.items ?? []
+      listData = listData.map(this.mapDataToComponentProps)
+      this.listData.push(...listData)
+    },
+    setListDataTotal(response = {}) {
+      this.listDataTotal = response.meta?.total ?? 0
+    },
+    async infiniteHandler($state) {
+      this.listDataCurrentPage += 1
+      try {
+        const response = await this.fetchAuthorListing({
+          page: this.listDataCurrentPage,
+        })
+        this.setListData(response)
+
+        if (this.listDataCurrentPage >= this.listDataPageLimit) {
+          $state.complete()
+        } else {
+          $state.loaded()
+        }
+      } catch (e) {
+        $state.error()
+      }
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.section {
+  background-color: #f2f2f2;
+  padding: 36px 0;
+  @include media-breakpoint-up(md) {
+    padding: 36px 25px 72px 25px;
+  }
+  @include media-breakpoint-up(xl) {
+    max-width: 1024px;
+    padding: 0;
+    margin: auto;
+  }
+  &__list {
+    @include media-breakpoint-up(md) {
+      margin: 8px 0 0 0;
+    }
+  }
+}
+
+.spinner {
+  margin: 20px 0 0 0;
+}
+</style>

--- a/pages/category/_name.vue
+++ b/pages/category/_name.vue
@@ -6,35 +6,24 @@
       :listTitleColor="currentSectionThemeColor"
       :listData="listData"
     />
-    <client-only>
-      <infinite-loading
-        v-if="shouldMountInfiniteLoading"
-        @infinite="infiniteHandler"
-      >
-        <UILoadmoreLoadingIcon slot="spinner" class="spinner" />
-        <!-- provide empty slot if we want to disable load messages locally -->
-        <!-- see: https://peachscript.github.io/vue-infinite-loading/guide/configure-load-msg.html#via-slot-sepcial-attribute -->
-        <div slot="no-more" />
-        <div slot="no-results" />
-        <div slot="error" />
-      </infinite-loading>
-    </client-only>
+    <UIInfiniteLoading
+      v-if="shouldMountInfiniteLoading"
+      @infinite="infiniteHandler"
+    />
   </section>
 </template>
 
 <script>
 import { mapState } from 'vuex'
-import InfiniteLoading from 'vue-infinite-loading'
-import UILoadmoreLoadingIcon from '~/components/UILoadmoreLoadingIcon.vue'
 import UIArticleList from '~/components/UIArticleList.vue'
+import UIInfiniteLoading from '~/components/UIInfiniteLoading.vue'
 import styleVariables from '~/scss/_variables.scss'
 
 export default {
   name: 'Category',
   components: {
-    InfiniteLoading,
-    UILoadmoreLoadingIcon,
     UIArticleList,
+    UIInfiniteLoading,
   },
   async fetch() {
     const response = await this.fetchCategoryListing({ page: 1 })
@@ -182,9 +171,5 @@ export default {
       margin: 8px 0 0 0;
     }
   }
-}
-
-.spinner {
-  margin: 20px 0 0 0;
 }
 </style>

--- a/pages/category/_name.vue
+++ b/pages/category/_name.vue
@@ -1,0 +1,190 @@
+<template>
+  <section class="section">
+    <UIArticleList
+      class="section__list"
+      :listTitle="currentCategoryTitle"
+      :listTitleColor="currentSectionThemeColor"
+      :listData="listData"
+    />
+    <client-only>
+      <infinite-loading
+        v-if="shouldMountInfiniteLoading"
+        @infinite="infiniteHandler"
+      >
+        <UILoadmoreLoadingIcon slot="spinner" class="spinner" />
+        <!-- provide empty slot if we want to disable load messages locally -->
+        <!-- see: https://peachscript.github.io/vue-infinite-loading/guide/configure-load-msg.html#via-slot-sepcial-attribute -->
+        <div slot="no-more" />
+        <div slot="no-results" />
+        <div slot="error" />
+      </infinite-loading>
+    </client-only>
+  </section>
+</template>
+
+<script>
+import { mapState } from 'vuex'
+import InfiniteLoading from 'vue-infinite-loading'
+import UILoadmoreLoadingIcon from '~/components/UILoadmoreLoadingIcon.vue'
+import UIArticleList from '~/components/UIArticleList.vue'
+import styleVariables from '~/scss/_variables.scss'
+
+export default {
+  name: 'Category',
+  components: {
+    InfiniteLoading,
+    UILoadmoreLoadingIcon,
+    UIArticleList,
+  },
+  async fetch() {
+    const response = await this.fetchCategoryListing({ page: 1 })
+    this.setListData(response)
+    this.setListDataTotal(response)
+    this.listDataCurrentPage += 1
+  },
+  data() {
+    return {
+      listData: [],
+      listDataCurrentPage: 0,
+      listDataMaxResults: 9,
+      listDataTotal: undefined,
+    }
+  },
+  computed: {
+    ...mapState({
+      sections: (state) => state.sections.data.items ?? [],
+    }),
+    categories() {
+      return this.sections.map((section) => section.categories).flat()
+    },
+
+    currentSectionData() {
+      return (
+        this.sections.find((section) =>
+          section.categories
+            .map((category) => category.name)
+            .find((name) => name === this.currentCategoryName)
+        ) ?? {}
+      )
+    },
+    currentSectionName() {
+      return this.currentSectionData.name
+    },
+    currentSectionThemeColor() {
+      const key = `sections-color-${this.currentSectionName}`
+      return styleVariables[key]
+    },
+    currentSectionId() {
+      return this.currentSectionData.id
+    },
+    currentSectionTitle() {
+      return this.currentSectionData.title
+    },
+
+    currentCategoryName() {
+      return this.$route.params.name
+    },
+    currentCategoryData() {
+      return (
+        this.categories.find(
+          (category) => category.name === this.currentCategoryName
+        ) ?? {}
+      )
+    },
+    currentCategoryTitle() {
+      return this.currentCategoryData.title
+    },
+    currentCategoryId() {
+      return this.currentCategoryData.id
+    },
+
+    listDataPageLimit() {
+      if (this.listDataTotal === undefined) {
+        return undefined
+      }
+      return Math.ceil(this.listDataTotal / this.listDataMaxResults)
+    },
+
+    // Constraint which prevent loadmore unexpectly
+    // if we navigating on client-side
+    // due to the list data of the first page has not been loaded.
+    shouldMountInfiniteLoading() {
+      return this.listDataCurrentPage >= 1
+    },
+  },
+  methods: {
+    stripHtmlTag(html = '') {
+      return html.replace(/<\/?[^>]+(>|$)/g, '')
+    },
+    mapDataToComponentProps(item) {
+      return {
+        id: item.id,
+        href: item.slug ? `/story/${item.slug}` : '/',
+        imgSrc: item.heroImage?.image?.resizedTargets?.mobile?.url ?? '',
+        imgText: this.currentSectionTitle,
+        imgTextBackgroundColor: this.currentSectionThemeColor,
+        infoTitle: item.title ?? '',
+        infoDescription: this.stripHtmlTag(item.brief?.html ?? ''),
+      }
+    },
+    async fetchCategoryListing({ page = 1 }) {
+      const response = await this.$fetchList({
+        maxResults: this.listDataMaxResults,
+        sort: '-publishedDate',
+        categories: [this.currentCategoryId],
+        page,
+      })
+      return response
+    },
+    setListData(response = {}) {
+      let listData = response.items ?? []
+      listData = listData.map(this.mapDataToComponentProps)
+      this.listData.push(...listData)
+    },
+    setListDataTotal(response = {}) {
+      this.listDataTotal = response.meta?.total ?? 0
+    },
+    async infiniteHandler($state) {
+      this.listDataCurrentPage += 1
+      try {
+        const response = await this.fetchCategoryListing({
+          page: this.listDataCurrentPage,
+        })
+        this.setListData(response)
+
+        if (this.listDataCurrentPage >= this.listDataPageLimit) {
+          $state.complete()
+        } else {
+          $state.loaded()
+        }
+      } catch (e) {
+        $state.error()
+      }
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.section {
+  background-color: #f2f2f2;
+  padding: 36px 0;
+  @include media-breakpoint-up(md) {
+    padding: 36px 25px 72px 25px;
+  }
+  @include media-breakpoint-up(xl) {
+    max-width: 1024px;
+    padding: 0;
+    margin: auto;
+  }
+  &__list {
+    @include media-breakpoint-up(md) {
+      margin: 8px 0 0 0;
+    }
+  }
+}
+
+.spinner {
+  margin: 20px 0 0 0;
+}
+</style>

--- a/pages/section/_name.vue
+++ b/pages/section/_name.vue
@@ -6,35 +6,24 @@
       :listTitleColor="currentSectionThemeColor"
       :listData="listData"
     />
-    <client-only>
-      <infinite-loading
-        v-if="shouldMountInfiniteLoading"
-        @infinite="infiniteHandler"
-      >
-        <UILoadmoreLoadingIcon slot="spinner" class="spinner" />
-        <!-- provide empty slot if we want to disable load messages locally -->
-        <!-- see: https://peachscript.github.io/vue-infinite-loading/guide/configure-load-msg.html#via-slot-sepcial-attribute -->
-        <div slot="no-more" />
-        <div slot="no-results" />
-        <div slot="error" />
-      </infinite-loading>
-    </client-only>
+    <UIInfiniteLoading
+      v-if="shouldMountInfiniteLoading"
+      @infinite="infiniteHandler"
+    />
   </section>
 </template>
 
 <script>
 import { mapState } from 'vuex'
-import InfiniteLoading from 'vue-infinite-loading'
-import UILoadmoreLoadingIcon from '~/components/UILoadmoreLoadingIcon.vue'
 import UIArticleList from '~/components/UIArticleList.vue'
+import UIInfiniteLoading from '~/components/UIInfiniteLoading.vue'
 import styleVariables from '~/scss/_variables.scss'
 
 export default {
   name: 'Section',
   components: {
-    InfiniteLoading,
-    UILoadmoreLoadingIcon,
     UIArticleList,
+    UIInfiniteLoading,
   },
   async fetch() {
     const response = await this.fetchSectionListing({ page: 1 })
@@ -158,9 +147,5 @@ export default {
       margin: 8px 0 0 0;
     }
   }
-}
-
-.spinner {
-  margin: 20px 0 0 0;
 }
 </style>

--- a/pages/section/_name.vue
+++ b/pages/section/_name.vue
@@ -94,7 +94,7 @@ export default {
     },
     mapDataToComponentProps(item) {
       return {
-        id: item._id,
+        id: item.id,
         href: item.slug ? `/story/${item.slug}` : '/',
         imgSrc: item.heroImage?.image?.resizedTargets?.mobile?.url ?? '',
         imgText: this.currentSectionTitle,


### PR DESCRIPTION
- 新增 `/category/:name` 與 `/author/:id` routes 對應之 page components 及對應測試。
- Notes:
  - 上述兩個 routes 與 `/section/:name` 之 html template 與 data-binding 邏輯相同，唯有 data fetching 與 data processing 邏輯稍有差異。
  - 由於上述原因，目前以下 page component 及對應測試有大量重複程式碼，由於目前 listing 頁面尚缺 `/topic/:id`, `/section/topic` 與 `/search/:query` 頁面尚未實作，待所有情境皆實作完成再來考慮針對重複的程式碼重構。
    - `/page/section/_name.vue`
    - `/page/category/_name.vue`
    - `/page/author/_id.vue`