### PR TITLE
feat: add keywords and section in firstTier in buildParams

### DIFF
--- a/plugins/requests/index.js
+++ b/plugins/requests/index.js
@@ -47,6 +47,8 @@ export function buildParams(params = {}) {
     'clean',
     'related',
     'keyword',
+    'keywords',
+    'section',
   ]
 
   if (isPureObject && Object.keys(params).length > 0) {


### PR DESCRIPTION
對應目前後端新開的 search endpoint：
`http://api.mirrormedia.mg/search?keywords={要搜尋的關鍵字}&section={時事/最新/瑪法達/財經理財/}`