### PR TITLE
feat: listing search page

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,5 +1,7 @@
 <template>
-  <div :class="[{ listing: isListing }]">
+  <div
+    :class="[{ listing: isListing, 'listing--white-background': isSearchPage }]"
+  >
     <ContainerHeader />
     <nuxt />
     <UIFooter :class="[{ 'footer--listing': isListing }]" />
@@ -42,6 +44,9 @@ export default {
       ]
       return listingRouteNames.includes(this.$route.name)
     },
+    isSearchPage() {
+      return this.$route.name === 'search-keyword'
+    },
   },
   methods: {
     commitTopicsData(result) {
@@ -68,6 +73,11 @@ export default {
   padding: 0 0 60px 0;
   @include media-breakpoint-up(xl) {
     padding: 0;
+  }
+
+  // most of the listing page's background-color is #f2f2f2, except search page
+  &--white-background {
+    background-color: white;
   }
 }
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -38,6 +38,7 @@ export default {
         'category-name',
         'author-id',
         'section-topic',
+        'search-keyword',
       ]
       return listingRouteNames.includes(this.$route.name)
     },

--- a/pages/__tests__/search.spec.js
+++ b/pages/__tests__/search.spec.js
@@ -236,4 +236,18 @@ describe('component methods', () => {
       },
     ])
   })
+  test('setListDataTotal and listDataPageLimit computed by total', () => {
+    const totalMock = 1234
+    const responseMock = {
+      hits: {
+        total: totalMock,
+      },
+    }
+    const wrapper = createWrapper(page)
+    wrapper.vm.setListDataTotal(responseMock)
+    expect(wrapper.vm.listDataTotal).toBe(totalMock)
+    expect(wrapper.vm.listDataPageLimit).toBe(
+      Math.ceil(totalMock / wrapper.vm.listDataMaxResults)
+    )
+  })
 })

--- a/pages/__tests__/search.spec.js
+++ b/pages/__tests__/search.spec.js
@@ -1,0 +1,239 @@
+import page from '../search/_keyword.vue'
+import UIArticleList from '~/components/UIArticleList.vue'
+import createWrapperHelper from '~/test/helpers/createWrapperHelper'
+
+const createWrapper = createWrapperHelper({
+  mocks: {
+    $route: {
+      params: {
+        keyword: '',
+      },
+    },
+  },
+  $store: {
+    state: {
+      sections: {
+        data: {
+          items: [],
+        },
+      },
+    },
+  },
+  stubs: ['client-only'],
+})
+
+describe('stripHtmlTag method', () => {
+  test('should strip html tags successfully', () => {
+    const wrapper = createWrapper(page)
+    const html = '<div><script></script><p>foo</p><p>bar</p><p>123</p></div>'
+    expect(wrapper.vm.stripHtmlTag(html)).toBe('foobar123')
+  })
+  test('should return the same result if there is not html tags', () => {
+    const wrapper = createWrapper(page)
+    const html = 'foobar123'
+    expect(wrapper.vm.stripHtmlTag(html)).toBe('foobar123')
+  })
+})
+
+describe('page title', () => {
+  test('should affect by search keyword provided from route params', () => {
+    const keywordMock = 'i am keyword'
+    const wrapper = createWrapper(page, {
+      mocks: {
+        $route: {
+          params: {
+            keyword: keywordMock,
+          },
+        },
+      },
+    })
+    const title = wrapper.find('h1')
+    expect(title.text()).toBe(keywordMock)
+  })
+})
+
+describe('section data', () => {
+  test('should get proper section title by section id provided by url query', () => {
+    const sectionIdMock = 'test-id'
+    const sectionTitleMock = 'test-title'
+    const sectionStoreMock = {
+      data: {
+        items: [
+          {
+            id: sectionIdMock,
+            title: sectionTitleMock,
+          },
+        ],
+      },
+    }
+    const wrapper = createWrapper(page, {
+      mocks: {
+        $route: {
+          query: {
+            section: sectionIdMock,
+          },
+        },
+        $store: {
+          state: {
+            sections: sectionStoreMock,
+          },
+        },
+      },
+    })
+    expect(wrapper.vm.sectionQueryTitle).toBe(sectionTitleMock)
+  })
+  // test('section title should be null if section query in url not exist', () => {
+  //   const wrapper = createWrapper(page)
+  //   expect(wrapper.vm.sectionQueryTitle).toBe(null)
+  // })
+  test('section title should be null if section id cannot be found in section store', () => {
+    const sectionIdMock = 'test-id'
+    const sectionTitleMock = 'test-title'
+    const sectionStoreMock = {
+      data: {
+        items: [
+          {
+            id: sectionIdMock,
+            title: sectionTitleMock,
+          },
+        ],
+      },
+    }
+    const wrapper = createWrapper(page, {
+      mocks: {
+        $route: {
+          query: {
+            section: 'id-not-exist-in-section-store',
+          },
+        },
+        $store: {
+          state: {
+            sections: sectionStoreMock,
+          },
+        },
+      },
+    })
+    expect(wrapper.vm.sectionQueryTitle).toBe(null)
+  })
+})
+
+describe('fetchSearchListing query object', () => {
+  test('should contain section property if url has section query', () => {
+    const keywordMock = 'keyword'
+    const sectionIdMock = 'test-id'
+    const sectionTitleMock = 'test-title'
+    const $fetchSearch = jest.fn(() => Promise.resolve())
+    const wrapper = createWrapper(page, {
+      mocks: {
+        $route: {
+          params: {
+            keyword: keywordMock,
+          },
+          query: {
+            section: sectionIdMock,
+          },
+        },
+        $store: {
+          state: {
+            sections: {
+              data: {
+                items: [
+                  {
+                    id: sectionIdMock,
+                    title: sectionTitleMock,
+                  },
+                ],
+              },
+            },
+          },
+        },
+        $fetchSearch,
+      },
+    })
+
+    wrapper.vm.fetchSearchListing()
+    expect($fetchSearch).toHaveBeenCalledWith({
+      maxResults: 9,
+      keywords: keywordMock,
+      section: sectionTitleMock, // this property should exist
+      page: 1,
+    })
+  })
+  test('should not contain section property if url do not has section query', () => {
+    const keywordMock = 'keyword'
+    const $fetchSearch = jest.fn(() => Promise.resolve())
+    const wrapper = createWrapper(page, {
+      mocks: {
+        $route: {
+          params: {
+            keyword: keywordMock,
+          },
+          query: {},
+        },
+        $fetchSearch,
+      },
+    })
+
+    wrapper.vm.fetchSearchListing()
+    expect($fetchSearch).toHaveBeenCalledWith({
+      maxResults: 9,
+      keywords: keywordMock,
+      page: 1,
+    })
+  })
+})
+
+describe('component methods', () => {
+  test('setListData', () => {
+    const idMock = 'id'
+    const slugMock = 'slug'
+    const imageUrlMock = 'imageurl'
+    const titleMock = 'title'
+    const briefMock = 'brief'
+    const briefHtmlMock = `<div>${briefMock}</div>`
+    const sectionTitleMock = 'section-title'
+    const responseMock = {
+      hits: {
+        hits: [
+          {
+            source: {
+              objectID: idMock,
+              slug: slugMock,
+              heroImage: {
+                image: {
+                  resizedTargets: {
+                    mobile: {
+                      url: imageUrlMock,
+                    },
+                  },
+                },
+              },
+              title: titleMock,
+              brief: briefHtmlMock,
+              sections: [
+                {
+                  title: sectionTitleMock,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    }
+
+    const wrapper = createWrapper(page)
+    wrapper.vm.setListData(responseMock)
+    const list = wrapper.find(UIArticleList)
+    expect(list.props().listData).toEqual([
+      {
+        id: idMock,
+        href: `/story/${slugMock}`,
+        imgSrc: imageUrlMock,
+        imgText: sectionTitleMock,
+        imgTextBackgroundColor: undefined, // value from scss variable not available in jest
+        infoTitle: titleMock,
+        infoDescription: briefMock,
+      },
+    ])
+  })
+})

--- a/pages/__tests__/search.spec.js
+++ b/pages/__tests__/search.spec.js
@@ -251,3 +251,24 @@ describe('component methods', () => {
     )
   })
 })
+
+describe('loadmore button', () => {
+  test('hide loadmore button if listData is empty', () => {
+    const wrapper = createWrapper(page)
+    wrapper.setData({
+      listDataTotal: 0,
+    })
+    const button = wrapper.find('.section__loadmore-button')
+    expect(button.exists()).toBe(false)
+  })
+  test('hide loadmore button if listData reach its page limit', () => {
+    const wrapper = createWrapper(page)
+    wrapper.setData({
+      listDataMaxResults: 9,
+      listDataTotal: 9,
+      listDataCurrentPage: 1, // listDataPageLimit will be 1(calculate by lsitDataMaxResults and listDataTotal)
+    })
+    const button = wrapper.find('.section__loadmore-button')
+    expect(button.exists()).toBe(false)
+  })
+})

--- a/pages/__tests__/section.spec.js
+++ b/pages/__tests__/section.spec.js
@@ -97,7 +97,6 @@ describe('component methods', () => {
     const responseMock = {
       items: [
         {
-          name: sectionNameMock,
           id: idMock,
           slug: slugMock,
           heroImage: {

--- a/pages/search/_keyword.vue
+++ b/pages/search/_keyword.vue
@@ -2,6 +2,11 @@
   <section class="section">
     <h1 class="section__title" v-text="currentKeyword" />
     <UIArticleList class="section__list" :listData="listData" />
+    <button
+      v-if="showLoadmoreButton"
+      class="section__loadmore-button"
+      v-text="textContentLoadmore"
+    />
   </section>
 </template>
 
@@ -19,14 +24,15 @@ export default {
     const response = await this.fetchSearchListing({ page: 1 })
     this.setListData(response)
     this.setListDataTotal(response)
-    // this.listDataCurrentPage += 1
+    this.listDataCurrentPage += 1
   },
   data() {
     return {
       listData: [],
-      // listDataCurrentPage: 0,
+      listDataCurrentPage: 0,
       listDataMaxResults: 9,
       listDataTotal: undefined,
+      textContentLoadmore: '更多文章',
     }
   },
   computed: {
@@ -51,6 +57,12 @@ export default {
         return undefined
       }
       return Math.ceil(this.listDataTotal / this.listDataMaxResults)
+    },
+    showLoadmoreButton() {
+      return (
+        this.listDataPageLimit &&
+        this.listDataCurrentPage < this.listDataPageLimit
+      )
     },
     // // Constraint which prevent loadmore unexpectly
     // // if we navigating on client-side

--- a/pages/search/_keyword.vue
+++ b/pages/search/_keyword.vue
@@ -118,13 +118,14 @@ export default {
 
 <style lang="scss" scoped>
 .section {
-  background-color: #f2f2f2;
+  background-color: white;
   padding: 36px 0;
   @include media-breakpoint-up(md) {
     padding: 36px 25px 72px 25px;
   }
   @include media-breakpoint-up(xl) {
     max-width: 1024px;
+    padding: 36px 0 0 0;
     margin: auto;
   }
   &__title {

--- a/pages/search/_keyword.vue
+++ b/pages/search/_keyword.vue
@@ -155,5 +155,20 @@ export default {
       margin: 8px 0 0 0;
     }
   }
+  &__loadmore-button {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: calc(100% - 16px - 16px);
+    height: 30px;
+    border: 1px solid #bcbcbc;
+    font-size: 16px;
+    color: black;
+    margin: 20px 16px;
+    @include media-breakpoint-up(md) {
+      width: 100%;
+      margin: 40px 0 0 0;
+    }
+  }
 }
 </style>

--- a/pages/search/_keyword.vue
+++ b/pages/search/_keyword.vue
@@ -18,7 +18,7 @@ export default {
   async fetch() {
     const response = await this.fetchSearchListing({ page: 1 })
     this.setListData(response)
-    // this.setListDataTotal(response)
+    this.setListDataTotal(response)
     // this.listDataCurrentPage += 1
   },
   data() {
@@ -26,7 +26,7 @@ export default {
       listData: [],
       // listDataCurrentPage: 0,
       listDataMaxResults: 9,
-      // listDataTotal: undefined,
+      listDataTotal: undefined,
     }
   },
   computed: {
@@ -46,12 +46,12 @@ export default {
           ?.title ?? null
       )
     },
-    // listDataPageLimit() {
-    //   if (this.listDataTotal === undefined) {
-    //     return undefined
-    //   }
-    //   return Math.ceil(this.listDataTotal / this.listDataMaxResults)
-    // },
+    listDataPageLimit() {
+      if (this.listDataTotal === undefined) {
+        return undefined
+      }
+      return Math.ceil(this.listDataTotal / this.listDataMaxResults)
+    },
     // // Constraint which prevent loadmore unexpectly
     // // if we navigating on client-side
     // // due to the list data of the first page has not been loaded.
@@ -97,9 +97,9 @@ export default {
       listData = listData.map(this.mapDataToComponentProps)
       this.listData.push(...listData)
     },
-    // setListDataTotal(response = {}) {
-    //   this.listDataTotal = response.meta?.total ?? 0
-    // },
+    setListDataTotal(response = {}) {
+      this.listDataTotal = response.hits?.total ?? 0
+    },
   },
 }
 </script>

--- a/pages/search/_keyword.vue
+++ b/pages/search/_keyword.vue
@@ -1,6 +1,6 @@
 <template>
   <section class="section">
-    <h1 v-text="currentKeyword" />
+    <h1 class="section__title" v-text="currentKeyword" />
     <UIArticleList class="section__list" :listData="listData" />
   </section>
 </template>
@@ -113,8 +113,30 @@ export default {
   }
   @include media-breakpoint-up(xl) {
     max-width: 1024px;
-    padding: 0;
     margin: auto;
+  }
+  &__title {
+    font-size: 48px;
+    color: #344951;
+    display: flex;
+    align-items: center;
+    padding: 0 32px;
+    @include media-breakpoint-up(md) {
+      padding: 0 10px;
+    }
+    &::after {
+      content: '';
+      margin: 0 0 0 10px;
+      display: inline-block;
+      flex: 1 1 auto;
+      height: 10px;
+      background: linear-gradient(
+        to right,
+        #bcbcbc 0%,
+        rgba(242, 242, 242, 1) 70%,
+        rgba(242, 242, 242, 1) 100%
+      );
+    }
   }
   &__list {
     @include media-breakpoint-up(md) {

--- a/pages/search/_keyword.vue
+++ b/pages/search/_keyword.vue
@@ -1,0 +1,125 @@
+<template>
+  <section class="section">
+    <h1 v-text="currentKeyword" />
+    <UIArticleList class="section__list" :listData="listData" />
+  </section>
+</template>
+
+<script>
+import { mapState } from 'vuex'
+import UIArticleList from '~/components/UIArticleList.vue'
+import styleVariables from '~/scss/_variables.scss'
+
+export default {
+  name: 'Search',
+  components: {
+    UIArticleList,
+  },
+  async fetch() {
+    const response = await this.fetchSearchListing({ page: 1 })
+    this.setListData(response)
+    // this.setListDataTotal(response)
+    // this.listDataCurrentPage += 1
+  },
+  data() {
+    return {
+      listData: [],
+      // listDataCurrentPage: 0,
+      listDataMaxResults: 9,
+      // listDataTotal: undefined,
+    }
+  },
+  computed: {
+    currentKeyword() {
+      return this.$route.params.keyword
+    },
+    ...mapState({
+      sections: (state) => state.sections.data.items ?? [],
+    }),
+    sectionQueryTitle() {
+      const sectionIdFromUrlQuery = this.$route.query?.section ?? ''
+      if (sectionIdFromUrlQuery === '') {
+        return null
+      }
+      return (
+        this.sections.find((section) => section.id === sectionIdFromUrlQuery)
+          ?.title ?? null
+      )
+    },
+    // listDataPageLimit() {
+    //   if (this.listDataTotal === undefined) {
+    //     return undefined
+    //   }
+    //   return Math.ceil(this.listDataTotal / this.listDataMaxResults)
+    // },
+    // // Constraint which prevent loadmore unexpectly
+    // // if we navigating on client-side
+    // // due to the list data of the first page has not been loaded.
+    // shouldMountInfiniteLoading() {
+    //   return this.listDataCurrentPage >= 1
+    // },
+  },
+  methods: {
+    stripHtmlTag(html = '') {
+      return html.replace(/<\/?[^>]+(>|$)/g, '')
+    },
+    getFirstSectionName(article = {}) {
+      return (article.sections ?? [])[0]?.name
+    },
+    mapDataToComponentProps(dataFromES) {
+      const item = dataFromES.source ?? {}
+      return {
+        id: item.objectID,
+        href: item.slug ? `/story/${item.slug}` : '/',
+        imgSrc: item.heroImage?.image?.resizedTargets?.mobile?.url,
+        imgText: (item.sections ?? [])[0]?.title,
+        imgTextBackgroundColor:
+          styleVariables[`sections-color-${this.getFirstSectionName(item)}`],
+        infoTitle: item.title ?? '',
+        infoDescription: this.stripHtmlTag(item.brief ?? ''),
+      }
+    },
+    async fetchSearchListing({ page = 1 } = {}) {
+      const response = await this.$fetchSearch({
+        maxResults: this.listDataMaxResults,
+        keywords: this.currentKeyword,
+
+        // add a section property conditonally
+        ...(this.sectionQueryTitle && {
+          section: this.sectionQueryTitle,
+        }),
+        page,
+      })
+      return response
+    },
+    setListData(response = {}) {
+      let listData = response.hits?.hits ?? []
+      listData = listData.map(this.mapDataToComponentProps)
+      this.listData.push(...listData)
+    },
+    // setListDataTotal(response = {}) {
+    //   this.listDataTotal = response.meta?.total ?? 0
+    // },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.section {
+  background-color: #f2f2f2;
+  padding: 36px 0;
+  @include media-breakpoint-up(md) {
+    padding: 36px 25px 72px 25px;
+  }
+  @include media-breakpoint-up(xl) {
+    max-width: 1024px;
+    padding: 0;
+    margin: auto;
+  }
+  &__list {
+    @include media-breakpoint-up(md) {
+      margin: 8px 0 0 0;
+    }
+  }
+}
+</style>


### PR DESCRIPTION
- 新增 `/search/:keyword?section={sectionId}` 頁面。
- 本頁之 loadmore 功能採手動方式，非無限捲軸，故有一個 loadmore button。
- 第一頁後的資料呈現待進行 api 串接。