### PR TITLE
build: upgrade @vue/test-utils and update api usage

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,24 +2,22 @@ module.exports = {
   root: true,
   env: {
     browser: true,
-    node: true
+    node: true,
   },
   parserOptions: {
-    parser: 'babel-eslint'
+    parser: 'babel-eslint',
   },
   extends: [
     '@nuxtjs',
     'prettier',
     'prettier/vue',
     'plugin:prettier/recommended',
-    'plugin:nuxt/recommended'
+    'plugin:nuxt/recommended',
   ],
-  plugins: [
-    'prettier'
-  ],
+  plugins: ['prettier'],
   // add your custom rules here
   rules: {
     'nuxt/no-cjs-in-config': 'off',
-    "vue/attribute-hyphenation": ['error', 'never']
-  }
+    'vue/attribute-hyphenation': ['error', 'never'],
+  },
 }

--- a/components/__tests__/ContainerHeader.spec.js
+++ b/components/__tests__/ContainerHeader.spec.js
@@ -45,7 +45,7 @@ describe('handleSendGA method', () => {
       eventAction: 'click',
       eventLabel: 'search',
     }
-    wrapper.find(UISearchBarWrapper).vm.$emit('sendGA', gaArgs)
+    wrapper.findComponent(UISearchBarWrapper).vm.$emit('sendGA', gaArgs)
     expect($ga.event).toBeCalledWith(gaArgs)
   })
 
@@ -64,7 +64,7 @@ describe('handleSendGA method', () => {
       eventAction: 'click',
       eventLabel: 'more subscribe',
     }
-    wrapper.find(UIOthersList).vm.$emit('sendGA', gaArgs)
+    wrapper.findComponent(UIOthersList).vm.$emit('sendGA', gaArgs)
     expect($ga.event).toBeCalledWith(gaArgs)
   })
 
@@ -83,7 +83,7 @@ describe('handleSendGA method', () => {
       eventAction: 'click',
       eventLabel: 'section news',
     }
-    wrapper.find(UIHeaderNavSection).vm.$emit('sendGA', gaArgs)
+    wrapper.findComponent(UIHeaderNavSection).vm.$emit('sendGA', gaArgs)
     expect($ga.event).toBeCalledWith(gaArgs)
   })
 
@@ -102,7 +102,7 @@ describe('handleSendGA method', () => {
       eventAction: 'click',
       eventLabel: 'topic 人造地獄',
     }
-    wrapper.find(UIHeaderNavTopic).vm.$emit('sendGA', gaArgs)
+    wrapper.findComponent(UIHeaderNavTopic).vm.$emit('sendGA', gaArgs)
     expect($ga.event).toBeCalledWith(gaArgs)
   })
 })

--- a/components/__tests__/UIArticleList.spec.js
+++ b/components/__tests__/UIArticleList.spec.js
@@ -47,7 +47,7 @@ describe('render list items', () => {
         listData,
       },
     })
-    const articles = wrapper.findAll(UIArticleCard)
+    const articles = wrapper.findAllComponents(UIArticleCard)
     expect(articles).toHaveLength(listData.length)
   })
   test('should deliver proper props to UIArticleCard that we provide from "listData" props', () => {
@@ -66,7 +66,7 @@ describe('render list items', () => {
         listData,
       },
     })
-    const article = wrapper.find(UIArticleCard)
+    const article = wrapper.findComponent(UIArticleCard)
     const listItemMock = listData[0]
     Object.entries(listItemMock).forEach((tuple) => {
       const key = tuple[0]

--- a/components/__tests__/UIOthersList.spec.js
+++ b/components/__tests__/UIOthersList.spec.js
@@ -38,12 +38,10 @@ describe('link list', () => {
     const wrapper = createWrapper(UIOthersList)
 
     const moreIcon = wrapper.find('.more-icon')
-    moreIcon.trigger('click')
-    await wrapper.vm.$nextTick()
+    await moreIcon.trigger('click')
     expect(wrapper.find('.link-list').exists()).toBe(true)
 
-    moreIcon.trigger('click')
-    await wrapper.vm.$nextTick()
+    await moreIcon.trigger('click')
     expect(wrapper.find('.link-list').exists()).toBe(false)
   })
 
@@ -56,8 +54,7 @@ describe('link list', () => {
       },
     })
 
-    document.body.dispatchEvent(new Event('click'))
-    await wrapper.vm.$nextTick()
+    await document.body.dispatchEvent(new Event('click'))
     expect(wrapper.find('.link-list').exists()).toBe(false)
   })
 })

--- a/components/__tests__/UISearchBar.spec.js
+++ b/components/__tests__/UISearchBar.spec.js
@@ -41,12 +41,10 @@ describe('search field', () => {
     const wrapper = createWrapper(UISearchBar)
 
     const searchIcon = wrapper.find('.search-icon')
-    searchIcon.trigger('click')
-    await wrapper.vm.$nextTick()
+    await searchIcon.trigger('click')
     expect(wrapper.find('.field').element.style.display).toBe('')
 
-    searchIcon.trigger('click')
-    await wrapper.vm.$nextTick()
+    await searchIcon.trigger('click')
     expect(wrapper.find('.field').element.style.display).toBe('none')
   })
 
@@ -59,8 +57,7 @@ describe('search field', () => {
       },
     })
 
-    document.body.dispatchEvent(new Event('click'))
-    await wrapper.vm.$nextTick()
+    await document.body.dispatchEvent(new Event('click'))
     expect(wrapper.find('.field').element.style.display).toBe('none')
   })
 })

--- a/components/__tests__/UISearchBar.spec.js
+++ b/components/__tests__/UISearchBar.spec.js
@@ -14,7 +14,9 @@ describe('custom events', () => {
     const wrapper = createWrapper(UISearchBar)
     const option = { title: '全部類別' }
 
-    wrapper.find(UISearchBarSelect).vm.$emit('setSelectedOption', option)
+    wrapper
+      .findComponent(UISearchBarSelect)
+      .vm.$emit('setSelectedOption', option)
     expect(wrapper.emitted().setSelectedOption[0]).toEqual([option])
   })
 
@@ -22,14 +24,14 @@ describe('custom events', () => {
     const wrapper = createWrapper(UISearchBar)
     const keyword = '明星'
 
-    wrapper.find(UISearchBarInput).vm.$emit('setText', keyword)
+    wrapper.findComponent(UISearchBarInput).vm.$emit('setText', keyword)
     expect(wrapper.emitted().setText[0]).toEqual([keyword])
   })
 
   test('emit search when UISearchBarInput.vue emits search', () => {
     const wrapper = createWrapper(UISearchBar)
 
-    wrapper.find(UISearchBarInput).vm.$emit('search')
+    wrapper.findComponent(UISearchBarInput).vm.$emit('search')
     expect(wrapper.emitted().search).toBeTruthy()
   })
 })

--- a/components/__tests__/UISearchBarDesktop.spec.js
+++ b/components/__tests__/UISearchBarDesktop.spec.js
@@ -14,14 +14,14 @@ describe('custom events', () => {
     const wrapper = createWrapper(UISearchBarDesktop)
     const keyword = '明星'
 
-    wrapper.find(UISearchBarInput).vm.$emit('setText', keyword)
+    wrapper.findComponent(UISearchBarInput).vm.$emit('setText', keyword)
     expect(wrapper.emitted().setText[0]).toEqual([keyword])
   })
 
   test('emit search when UISearchBarInput.vue emits search', () => {
     const wrapper = createWrapper(UISearchBarDesktop)
 
-    wrapper.find(UISearchBarInput).vm.$emit('search')
+    wrapper.findComponent(UISearchBarInput).vm.$emit('search')
     expect(wrapper.emitted().search).toBeTruthy()
   })
 
@@ -29,7 +29,9 @@ describe('custom events', () => {
     const wrapper = createWrapper(UISearchBarDesktop)
     const option = { title: '全部類別' }
 
-    wrapper.find(UISearchBarSelect).vm.$emit('setSelectedOption', option)
+    wrapper
+      .findComponent(UISearchBarSelect)
+      .vm.$emit('setSelectedOption', option)
     expect(wrapper.emitted().setSelectedOption[0]).toEqual([option])
   })
 

--- a/components/__tests__/UISearchBarInput.spec.js
+++ b/components/__tests__/UISearchBarInput.spec.js
@@ -9,8 +9,7 @@ describe('input feature', () => {
   test('emit the text when users type', async () => {
     const wrapper = createWrapper(UISearchBarInput)
 
-    wrapper.find('input').setValue(keyword)
-    await wrapper.vm.$nextTick()
+    await wrapper.find('input').setValue(keyword)
     expect(wrapper.emitted().setText[0]).toEqual([keyword])
   })
 
@@ -21,11 +20,9 @@ describe('input feature', () => {
     input.trigger('keydown.enter', {
       isComposing: true,
     })
-    // await wrapper.vm.$nextTick()
     expect(wrapper.emitted().search).toBeFalsy()
 
     input.trigger('keydown.enter')
-    // await wrapper.vm.$nextTick()
     expect(wrapper.emitted().search).toBeTruthy()
   })
 })

--- a/components/__tests__/UISearchBarInput.spec.js
+++ b/components/__tests__/UISearchBarInput.spec.js
@@ -14,18 +14,18 @@ describe('input feature', () => {
     expect(wrapper.emitted().setText[0]).toEqual([keyword])
   })
 
-  test('emit search when users press the Enter key', async () => {
+  test('emit search when users press the Enter key', () => {
     const wrapper = createWrapper(UISearchBarInput)
     const input = wrapper.find('input')
 
     input.trigger('keydown.enter', {
       isComposing: true,
     })
-    await wrapper.vm.$nextTick()
+    // await wrapper.vm.$nextTick()
     expect(wrapper.emitted().search).toBeFalsy()
 
     input.trigger('keydown.enter')
-    await wrapper.vm.$nextTick()
+    // await wrapper.vm.$nextTick()
     expect(wrapper.emitted().search).toBeTruthy()
   })
 })

--- a/components/__tests__/UISearchBarSelect.spec.js
+++ b/components/__tests__/UISearchBarSelect.spec.js
@@ -35,12 +35,10 @@ describe('select feature', () => {
     const wrapper = createWrapper(UISearchBarSelect)
     const displayedField = wrapper.find('.displayed-field')
 
-    displayedField.trigger('click')
-    await wrapper.vm.$nextTick()
+    await displayedField.trigger('click')
     expect(wrapper.find('.option-filed').element.style.display).toBe('')
 
-    displayedField.trigger('click')
-    await wrapper.vm.$nextTick()
+    await displayedField.trigger('click')
     expect(wrapper.find('.option-filed').element.style.display).toBe('none')
   })
 
@@ -53,8 +51,7 @@ describe('select feature', () => {
       },
     })
 
-    wrapper.find('.option-filed li:nth-child(2)').trigger('click')
-    await wrapper.vm.$nextTick()
+    await wrapper.find('.option-filed li:nth-child(2)').trigger('click')
     expect(
       wrapper.find('.option-filed li:nth-child(2)').classes('selected')
     ).toBe(true)
@@ -77,8 +74,7 @@ describe('select feature', () => {
       { title: '全部類別' },
     ])
 
-    wrapper.find('.option-filed li:nth-child(2)').trigger('click')
-    await wrapper.vm.$nextTick()
+    await wrapper.find('.option-filed li:nth-child(2)').trigger('click')
     expect(wrapper.emitted().setSelectedOption[1]).toEqual([{ title: '文化' }])
   })
 
@@ -91,8 +87,7 @@ describe('select feature', () => {
       },
     })
 
-    document.body.dispatchEvent(new Event('click'))
-    await wrapper.vm.$nextTick()
+    await document.body.dispatchEvent(new Event('click'))
     expect(wrapper.find('.option-filed').element.style.display).toBe('none')
   })
 })

--- a/components/__tests__/UISearchBarWrapper.spec.js
+++ b/components/__tests__/UISearchBarWrapper.spec.js
@@ -15,7 +15,7 @@ describe('search feature', () => {
     const wrapper = createWrapper(UISearchBarWrapper)
     const option = { title: '全部類別' }
 
-    wrapper.find(UISearchBar).vm.$emit('setSelectedOption', option)
+    wrapper.findComponent(UISearchBar).vm.$emit('setSelectedOption', option)
     expect(wrapper.vm.selectedOption).toEqual(option)
   })
 
@@ -23,7 +23,7 @@ describe('search feature', () => {
     const wrapper = createWrapper(UISearchBarWrapper)
     const keyword = '明星'
 
-    wrapper.find(UISearchBar).vm.$emit('setText', keyword)
+    wrapper.findComponent(UISearchBar).vm.$emit('setText', keyword)
     expect(wrapper.vm.keyword).toBe(keyword)
   })
 
@@ -42,7 +42,7 @@ describe('search feature', () => {
         $router,
       },
     })
-    const searchBarVM = wrapper.find(UISearchBar).vm
+    const searchBarVM = wrapper.findComponent(UISearchBar).vm
 
     searchBarVM.$emit('search')
     expect($router.push).toBeCalledWith('/search/明星')
@@ -95,7 +95,7 @@ describe('emitGA method', () => {
       eventAction: 'click',
       eventLabel: 'search',
     }
-    wrapper.find(UISearchBarDesktop).vm.$emit('sendGA', gaArgs)
+    wrapper.findComponent(UISearchBarDesktop).vm.$emit('sendGA', gaArgs)
     expect(wrapper.emitted().sendGA[0]).toEqual([gaArgs])
   })
 })

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@nuxtjs/eslint-module": "^2.0.0",
     "@nuxtjs/google-analytics": "^2.3.0",
     "@nuxtjs/style-resources": "^1.0.0",
-    "@vue/test-utils": "^1.0.0-beta.33",
+    "@vue/test-utils": "^1.0.3",
     "babel-eslint": "^10.0.1",
     "babel-jest": "^25.3.0",
     "babel-plugin-lodash": "^3.3.4",

--- a/pages/__tests__/author.spec.js
+++ b/pages/__tests__/author.spec.js
@@ -73,7 +73,7 @@ describe('component methods', () => {
 
     const wrapper = createWrapper(page)
     wrapper.vm.setListData(responseMock)
-    const list = wrapper.find(UIArticleList)
+    const list = wrapper.findComponent(UIArticleList)
     expect(list.props().listData).toEqual([
       {
         id: idMock,

--- a/pages/__tests__/category.spec.js
+++ b/pages/__tests__/category.spec.js
@@ -111,7 +111,7 @@ describe('category data', () => {
         },
       },
     })
-    const list = wrapper.find(UIArticleList)
+    const list = wrapper.findComponent(UIArticleList)
     expect(wrapper.vm.currentCategoryId).toBe(categoryIdMock)
     expect(list.props().listTitle).toBe(categoryTitleMock)
   })
@@ -185,7 +185,7 @@ describe('component methods', () => {
     })
 
     wrapper.vm.setListData(responseMock)
-    const list = wrapper.find(UIArticleList)
+    const list = wrapper.findComponent(UIArticleList)
     expect(list.props().listData).toEqual([
       {
         id: idMock,

--- a/pages/__tests__/search.spec.js
+++ b/pages/__tests__/search.spec.js
@@ -223,7 +223,7 @@ describe('component methods', () => {
 
     const wrapper = createWrapper(page)
     wrapper.vm.setListData(responseMock)
-    const list = wrapper.find(UIArticleList)
+    const list = wrapper.findComponent(UIArticleList)
     expect(list.props().listData).toEqual([
       {
         id: idMock,

--- a/pages/__tests__/section.spec.js
+++ b/pages/__tests__/section.spec.js
@@ -65,7 +65,7 @@ describe('section data', () => {
         },
       },
     })
-    const list = wrapper.find(UIArticleList)
+    const list = wrapper.findComponent(UIArticleList)
     expect(wrapper.vm.currentSectionId).toBe(sectionIdMock)
     expect(list.props().listTitle).toBe(sectionTitleMock)
   })
@@ -132,7 +132,7 @@ describe('component methods', () => {
     })
 
     wrapper.vm.setListData(responseMock)
-    const list = wrapper.find(UIArticleList)
+    const list = wrapper.findComponent(UIArticleList)
     expect(list.props().listData).toEqual([
       {
         id: idMock,

--- a/pages/__tests__/section.topic.spec.js
+++ b/pages/__tests__/section.topic.spec.js
@@ -52,7 +52,7 @@ describe('component methods', () => {
     const wrapper = createWrapper(page)
 
     wrapper.vm.setListData(responseMock)
-    const list = wrapper.find(UIArticleList)
+    const list = wrapper.findComponent(UIArticleList)
     expect(list.props().listData).toEqual([
       {
         id: idMock,
@@ -94,7 +94,7 @@ describe('component methods', () => {
 
     const wrapper = createWrapper(page)
     wrapper.vm.setListData(responseMock)
-    const list = wrapper.find(UIArticleList)
+    const list = wrapper.findComponent(UIArticleList)
     expect(list.props().listData).toEqual([
       {
         id: idMock,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1579,10 +1579,10 @@
   optionalDependencies:
     prettier "^1.18.2"
 
-"@vue/test-utils@^1.0.0-beta.33":
-  version "1.0.0-beta.33"
-  resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-1.0.0-beta.33.tgz#627511afbd4307e7557634f860a1b985bd25d9cd"
-  integrity sha512-Xzqoe0lTLn3QRWfjhmKPOXYR86l0Y+g/zPHaheJQOkPLj5ojJl3rG0t4F3kXFWuLD88YzUVRMIBWOG7v9KOJQQ==
+"@vue/test-utils@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-1.0.3.tgz#587c4dd9b424b66022f188c19bc605da2ce91c6f"
+  integrity sha512-mmsKXZSGfvd0bH05l4SNuczZ2MqlJH2DWhiul5wJXFxbf/gRRd2UL4QZgozEMQ30mRi9i4/+p4JJat8S4Js64Q==
   dependencies:
     dom-event-types "^1.0.0"
     lodash "^4.17.15"


### PR DESCRIPTION
- 升版 @vue/test-utils，基於該升版，有以下修正：
  - 替換 `find ` 用於 component 的狀況，改使用 `findComponent `, ref [[1]](https://vue-test-utils.vuejs.org/api/wrapper/find.html) [[2]](https://vue-test-utils.vuejs.org/api/wrapper/#findcomponent)
  - 省略 `await wrapper.vm.$nextTick()`：~實際上只有 `UISearchBarInput.spec.js` 省略掉後可以通過測試，而且個人覺得這個測試省略掉後仍有機會失敗，因此先用註解的方式，而其他的測試都沒有省略 `await wrapper.vm.$nextTick()`~

- 修正 `.eslintrc.js` 語法風格