### PR TITLE
feat: gpt-plugin

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -19,5 +19,6 @@ module.exports = {
   setupFiles: [
     '<rootDir>/plugins/vueDirectivesGlobal.js',
     '<rootDir>/plugins/vuePluginsGlobal.js',
+    '<rootDir>/plugins/vuePluginsGlobal.client.js',
   ],
 }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -35,6 +35,7 @@ module.exports = {
    */
   plugins: [
     '~/plugins/vuePluginsGlobal.js',
+    '~/plugins/vuePluginsGlobal.client.js',
     '~/plugins/vueDirectivesGlobal.js',
     '~/plugins/requests/index.js',
   ],

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -15,12 +15,6 @@ module.exports = {
       },
     ],
     link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }],
-    script: [
-      {
-        src: 'https://securepubads.g.doubleclick.net/tag/js/gpt.js',
-        async: true,
-      },
-    ],
   },
   /*
    ** Customize the progress-bar color

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -15,6 +15,12 @@ module.exports = {
       },
     ],
     link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }],
+    script: [
+      {
+        src: 'https://securepubads.g.doubleclick.net/tag/js/gpt.js',
+        async: true,
+      },
+    ],
   },
   /*
    ** Customize the progress-bar color

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="container">
     <div>
+      <GPTAD />
       <h1 class="title">
         mirror-media-nuxt
       </h1>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="container">
     <div>
-      <GPTAD />
       <h1 class="title">
         mirror-media-nuxt
       </h1>

--- a/plugins/gpt-ad/__tests__/gpt-ad.spec.js
+++ b/plugins/gpt-ad/__tests__/gpt-ad.spec.js
@@ -1,0 +1,141 @@
+import { mount, createLocalVue } from '@vue/test-utils'
+import plugin from '../index'
+
+describe('adNetwork settings', () => {
+  test("should throw error if adNetwork not provided via plugin option or component's adNetwork props", () => {
+    // Disable Vue warn from lifecycle hooks temporarily
+    console.error = () => {}
+
+    const localVue = createLocalVue()
+    localVue.use(
+      plugin
+      // adNetwork is missing in plugin option
+      // {
+      //   adNetwork: '',
+      // }
+    )
+
+    const TestWrapperComponent = {
+      template: `
+        <div>
+          <!-- adNetwork is missing in component props -->
+          <GPTAD
+            :adNetwork="undefined"
+            :adUnit="'adUnitMock'"
+            :adSize="[0, 0]"
+          />
+        </div>
+      `,
+    }
+    expect(() => {
+      mount(TestWrapperComponent, {
+        localVue,
+      })
+    }).toThrowError(
+      "GPT Ad network-code not found. Please provide network-code via plugin option or component's adNetwork props, see https://developers.google.com/doubleclick-gpt/guides/get-started"
+    )
+  })
+
+  test('should be a proper value from Vue plugin option', () => {
+    const adNetworkMock = 'adNetwork'
+    const adUnitMock = 'adUnit'
+    const adSizeMock = [123, 456]
+    const localVue = createLocalVue()
+    localVue.use(plugin, {
+      adNetwork: adNetworkMock,
+    })
+
+    const TestWrapperComponent = {
+      template: `
+        <div>
+          <!-- adNetwork is missing in component props -->
+          <GPTAD
+            class="ad"
+            :adNetwork="undefined"
+            :adUnit="adUnit"
+            :adSize="adSize"
+          />
+        </div>
+      `,
+      data() {
+        return {
+          adUnit: adUnitMock,
+          adSize: adSizeMock,
+        }
+      },
+    }
+    const wrapper = mount(TestWrapperComponent, {
+      localVue,
+    })
+    const ad = wrapper.find('.ad')
+    expect(ad.vm.$adNetwork).toBe(adNetworkMock)
+  })
+
+  test("should be a proper value from component's adNetwork props", () => {
+    const adNetworkMockPluginOption = 'adNetwork'
+    const adNetworkMockComponentProps = 'adNetworkComponentProps'
+    const localVue = createLocalVue()
+    localVue.use(plugin, {
+      adNetwork: adNetworkMockPluginOption,
+    })
+
+    const TestWrapperComponent = {
+      template: `
+        <div>
+          <GPTAD
+            class="ad"
+            :adNetwork="adNetwork"
+            :adUnit="'adUnitMock'"
+            :adSize="[0, 0]"
+          />
+        </div>
+      `,
+      data() {
+        return {
+          adNetwork: adNetworkMockComponentProps,
+        }
+      },
+    }
+    const wrapper = mount(TestWrapperComponent, {
+      localVue,
+    })
+    const ad = wrapper.find('.ad')
+    expect(ad.vm.$adNetwork).not.toBe(adNetworkMockPluginOption)
+    expect(ad.vm.$adNetwork).toBe(adNetworkMockComponentProps)
+  })
+})
+
+describe('GPT script', () => {
+  test('should insert only one script if multiple GPTAD component mounted', () => {
+    const adNetworkMock = 'adNetwork'
+    const localVue = createLocalVue()
+    localVue.use(plugin, {
+      adNetwork: adNetworkMock,
+    })
+
+    const TestWrapperComponent = {
+      template: `
+        <div>
+          <!-- We mount two GPTAD components here -->
+          <GPTAD
+            class="ad"
+            :adUnit="'adUnitMock1'"
+            :adSize="[0, 0]"
+          />
+          <GPTAD
+            class="ad"
+            :adUnit="'adUnitMock2'"
+            :adSize="[0, 0]"
+          />
+        </div>
+      `,
+    }
+    mount(TestWrapperComponent, {
+      localVue,
+    })
+    const scripts = document.querySelectorAll(
+      "script[src='https://securepubads.g.doubleclick.net/tag/js/gpt.js']"
+    )
+    expect(scripts).toHaveLength(1)
+  })
+})

--- a/plugins/gpt-ad/__tests__/gpt-ad.spec.js
+++ b/plugins/gpt-ad/__tests__/gpt-ad.spec.js
@@ -139,3 +139,32 @@ describe('GPT script', () => {
     expect(scripts).toHaveLength(1)
   })
 })
+
+describe('GPTAD component computeds', () => {
+  test('adUnitPath and adOptDiv', () => {
+    const adNetworkMock = 'adNetwork'
+    const adUnitMock = 'adUnit'
+    const localVue = createLocalVue()
+    localVue.use(plugin, {
+      adNetwork: adNetworkMock,
+    })
+
+    const TestWrapperComponent = {
+      template: `
+        <div>
+          <GPTAD
+            class="ad"
+            :adUnit="'${adUnitMock}'"
+            :adSize="[0, 0]"
+          />
+        </div>
+      `,
+    }
+    const wrapper = mount(TestWrapperComponent, {
+      localVue,
+    })
+    const ad = wrapper.find('.ad')
+    expect(ad.vm.adUnitPath).toBe(`/${adNetworkMock}/${adUnitMock}`)
+    expect(ad.vm.adOptDiv).toBe(`/${adNetworkMock}/${adUnitMock}`)
+  })
+})

--- a/plugins/gpt-ad/__tests__/gpt-ad.spec.js
+++ b/plugins/gpt-ad/__tests__/gpt-ad.spec.js
@@ -207,3 +207,84 @@ describe('GPTAD component computeds', () => {
     expect(ad.vm.adOptDiv).toBe(`/${adNetworkMock}/${adUnitMock}`)
   })
 })
+
+describe('different ad sizes', () => {
+  test('fixed-size ads', () => {
+    const localVue = createLocalVue()
+    localVue.use(plugin, {
+      adNetwork: 'adNetwork',
+    })
+
+    const widthMock = 123
+    const TestWrapperComponent = {
+      template: `
+        <div>
+          <GPTAD
+            class="ad"
+            :adUnit="'adUnit'"
+            :adSize="[${widthMock}, 456]"
+          />
+        </div>
+      `,
+    }
+    const wrapper = mount(TestWrapperComponent, {
+      localVue,
+    })
+    const ad = wrapper.find('.ad')
+    expect(ad.vm.adSizeType).toBe('fixed')
+    expect(ad.element.style.width).toBe(`${widthMock}px`)
+  })
+  test('mluti-size ads', () => {
+    const localVue = createLocalVue()
+    localVue.use(plugin, {
+      adNetwork: 'adNetwork',
+    })
+
+    const maxWidthMock = 999
+    const TestWrapperComponent = {
+      template: `
+        <div>
+          <GPTAD
+            class="ad"
+            :adUnit="'adUnit'"
+            :adSize="[
+              [123, 456],
+              [456, 789],
+              [${maxWidthMock}, 123]
+            ]"
+          />
+        </div>
+      `,
+    }
+    const wrapper = mount(TestWrapperComponent, {
+      localVue,
+    })
+    const ad = wrapper.find('.ad')
+    expect(ad.vm.adSizeType).toBe('multi')
+    expect(ad.element.style.width).toBe(`${maxWidthMock}px`)
+  })
+  test('fluid ads', () => {
+    const localVue = createLocalVue()
+    localVue.use(plugin, {
+      adNetwork: 'adNetwork',
+    })
+
+    const TestWrapperComponent = {
+      template: `
+        <div>
+          <GPTAD
+            class="ad"
+            :adUnit="'adUnit'"
+            :adSize="['fluid']"
+          />
+        </div>
+      `,
+    }
+    const wrapper = mount(TestWrapperComponent, {
+      localVue,
+    })
+    const ad = wrapper.find('.ad')
+    expect(ad.vm.adSizeType).toBe('fluid')
+    expect(ad.element.style.width).toBe('100%')
+  })
+})

--- a/plugins/gpt-ad/__tests__/gpt-ad.spec.js
+++ b/plugins/gpt-ad/__tests__/gpt-ad.spec.js
@@ -105,6 +105,45 @@ describe('adNetwork settings', () => {
   })
 })
 
+describe('mode setting', () => {
+  test('should insert "test_" in front of adUnit if mode is "dev"', () => {
+    const pluginMode = 'dev'
+    const adNetworkMock = 'adNetwork'
+    const adUnitMock = 'adUnit'
+    const adSizeMock = [123, 456]
+    const localVue = createLocalVue()
+    localVue.use(plugin, {
+      adNetwork: adNetworkMock,
+      mode: pluginMode,
+    })
+
+    const TestWrapperComponent = {
+      template: `
+        <div>
+          <!-- adNetwork is missing in component props -->
+          <GPTAD
+            class="ad"
+            :adNetwork="undefined"
+            :adUnit="adUnit"
+            :adSize="adSize"
+          />
+        </div>
+      `,
+      data() {
+        return {
+          adUnit: adUnitMock,
+          adSize: adSizeMock,
+        }
+      },
+    }
+    const wrapper = mount(TestWrapperComponent, {
+      localVue,
+    })
+    const ad = wrapper.find('.ad')
+    expect(ad.vm.$adUnit).toBe(`test_${adUnitMock}`)
+  })
+})
+
 describe('GPT script', () => {
   test('should insert only one script if multiple GPTAD component mounted', () => {
     const adNetworkMock = 'adNetwork'

--- a/plugins/gpt-ad/__tests__/gpt-ad.spec.js
+++ b/plugins/gpt-ad/__tests__/gpt-ad.spec.js
@@ -67,7 +67,7 @@ describe('adNetwork settings', () => {
     const wrapper = mount(TestWrapperComponent, {
       localVue,
     })
-    const ad = wrapper.find('.ad')
+    const ad = wrapper.get('.ad')
     expect(ad.vm.$adNetwork).toBe(adNetworkMock)
   })
 
@@ -99,7 +99,7 @@ describe('adNetwork settings', () => {
     const wrapper = mount(TestWrapperComponent, {
       localVue,
     })
-    const ad = wrapper.find('.ad')
+    const ad = wrapper.get('.ad')
     expect(ad.vm.$adNetwork).not.toBe(adNetworkMockPluginOption)
     expect(ad.vm.$adNetwork).toBe(adNetworkMockComponentProps)
   })
@@ -139,7 +139,7 @@ describe('mode setting', () => {
     const wrapper = mount(TestWrapperComponent, {
       localVue,
     })
-    const ad = wrapper.find('.ad')
+    const ad = wrapper.get('.ad')
     expect(ad.vm.$adUnit).toBe(`test_${adUnitMock}`)
   })
 })
@@ -202,7 +202,7 @@ describe('GPTAD component computeds', () => {
     const wrapper = mount(TestWrapperComponent, {
       localVue,
     })
-    const ad = wrapper.find('.ad')
+    const ad = wrapper.get('.ad')
     expect(ad.vm.adUnitPath).toBe(`/${adNetworkMock}/${adUnitMock}`)
     expect(ad.vm.adOptDiv).toBe(`/${adNetworkMock}/${adUnitMock}`)
   })
@@ -230,7 +230,7 @@ describe('different ad sizes', () => {
     const wrapper = mount(TestWrapperComponent, {
       localVue,
     })
-    const ad = wrapper.find('.ad')
+    const ad = wrapper.get('.ad')
     expect(ad.vm.adSizeType).toBe('fixed')
     expect(ad.element.style.width).toBe(`${widthMock}px`)
   })
@@ -259,7 +259,7 @@ describe('different ad sizes', () => {
     const wrapper = mount(TestWrapperComponent, {
       localVue,
     })
-    const ad = wrapper.find('.ad')
+    const ad = wrapper.get('.ad')
     expect(ad.vm.adSizeType).toBe('multi')
     expect(ad.element.style.width).toBe(`${maxWidthMock}px`)
   })
@@ -283,7 +283,7 @@ describe('different ad sizes', () => {
     const wrapper = mount(TestWrapperComponent, {
       localVue,
     })
-    const ad = wrapper.find('.ad')
+    const ad = wrapper.get('.ad')
     expect(ad.vm.adSizeType).toBe('fluid')
     expect(ad.element.style.width).toBe('100%')
   })

--- a/plugins/gpt-ad/index.js
+++ b/plugins/gpt-ad/index.js
@@ -2,19 +2,26 @@ import GPTAD from './index.vue'
 import { insertGPTScript } from './util'
 
 let isGPTScriptInserted = false
+const GPTAdSlotsDefined = {}
 
 export default {
   install(Vue, options = {}) {
+    Vue.prototype.$setGPTAdSlotsDefined = function (key, value) {
+      GPTAdSlotsDefined[key] = value
+    }
+    Vue.prototype.$getGPTAdSlotsDefined = function (key) {
+      return GPTAdSlotsDefined[key]
+    }
+
     let Component = Vue.extend(GPTAD)
     Component = Component.extend({
       beforeMount() {
         if (!isGPTScriptInserted) {
           insertGPTScript()
           isGPTScriptInserted = true
+          window.googletag = window.googletag || {}
+          window.googletag.cmd = window.googletag.cmd || []
         }
-
-        window.googletag = window.googletag || {}
-        window.googletag.cmd = window.googletag.cmd || []
 
         window.googletag.cmd.push(() => {
           /*

--- a/plugins/gpt-ad/index.js
+++ b/plugins/gpt-ad/index.js
@@ -59,6 +59,15 @@ export default {
       })
     }
 
+    const mode = options?.mode ?? 'prod'
+    Component = Component.extend({
+      data() {
+        return {
+          mode,
+        }
+      },
+    })
+
     Vue.component('GPTAD', Component)
   },
 }

--- a/plugins/gpt-ad/index.js
+++ b/plugins/gpt-ad/index.js
@@ -1,7 +1,57 @@
 import GPTAD from './index.vue'
+import { insertGPTScript } from './util'
+
+let isGPTScriptInserted = false
 
 export default {
-  install(Vue, options) {
-    Vue.component('GPTAD', GPTAD)
+  install(Vue, options = {}) {
+    let Component = Vue.extend(GPTAD)
+    Component = Component.extend({
+      beforeMount() {
+        if (!isGPTScriptInserted) {
+          insertGPTScript()
+          isGPTScriptInserted = true
+        }
+
+        window.googletag = window.googletag || {}
+        window.googletag.cmd = window.googletag.cmd || []
+
+        window.googletag.cmd.push(() => {
+          /*
+           * Do not use lazy loading with SRA.
+           *
+           * With lazy loading in SRA,
+           * GPT will fetching multiple ads at the same time,
+           * which cause the call for the first ad and all other ad slots is made.
+           * https://developers.google.com/doubleclick-gpt/reference#googletag.PubAdsService_enableSingleRequest
+           */
+          // window.googletag.pubads().enableSingleRequest()
+
+          window.googletag.pubads().enableLazyLoad({
+            // Fetch slots within 1.5 viewports.
+            fetchMarginPercent: 150,
+            // Render slots within 1 viewports.
+            renderMarginPercent: 100,
+            // Double the above values on mobile, where viewports are smaller
+            // and users tend to scroll faster.
+            mobileScaling: 2.0,
+          })
+          window.googletag.pubads().collapseEmptyDivs()
+          window.googletag.enableServices()
+        })
+      },
+    })
+
+    if (options.adNetwork) {
+      Component = Component.extend({
+        data() {
+          return {
+            adNetworkDefault: options.adNetwork,
+          }
+        },
+      })
+    }
+
+    Vue.component('GPTAD', Component)
   },
 }

--- a/plugins/gpt-ad/index.js
+++ b/plugins/gpt-ad/index.js
@@ -1,0 +1,7 @@
+import GPTAD from './index.vue'
+
+export default {
+  install(Vue, options) {
+    Vue.component('GPTAD', GPTAD)
+  },
+}

--- a/plugins/gpt-ad/index.vue
+++ b/plugins/gpt-ad/index.vue
@@ -92,6 +92,25 @@ export default {
       window.googletag.cmd.push(() => {
         window.googletag.display(this.adOptDiv)
       })
+
+      // see: https://developers.google.com/doubleclick-gpt/reference#googletag.service-addeventlistenereventtype,-listener
+      window.googletag.cmd.push(() => {
+        const pubads = window.googletag.pubads()
+        const events = [
+          'slotRequested',
+          'slotRenderEnded',
+          'impressionViewable',
+          'slotOnload',
+          'slotVisibilityChanged',
+        ]
+        events.forEach((event) => {
+          pubads.addEventListener(event, (e) => {
+            if (e.slot === this.adSlot) {
+              this.$emit(event, e)
+            }
+          })
+        })
+      })
     } else {
       window.googletag.cmd.push(() => {
         this.adSlot = adSlot

--- a/plugins/gpt-ad/index.vue
+++ b/plugins/gpt-ad/index.vue
@@ -1,13 +1,74 @@
 <template>
-  <div></div>
+  <div
+    :id="adOptDiv"
+    :style="{
+      width: `${adSize[0]}px`,
+      height: `${adSize[1]}px`,
+    }"
+  />
 </template>
 
 <script>
+import _ from 'lodash'
+
 export default {
+  props: {
+    adNetwork: {
+      type: String,
+      default: undefined,
+    },
+    adUnit: {
+      type: String,
+      required: true,
+    },
+    adSize: {
+      type: Array,
+      required: true,
+      validator(value) {
+        return (
+          value.length === 2 &&
+          value.reduce((acc, curr) => acc && _.isFinite(curr), true)
+        )
+      },
+    },
+  },
+  data() {
+    return {
+      adSlot: undefined,
+    }
+  },
+  computed: {
+    $adNetwork() {
+      return this.adNetwork || this.adNetworkDefault
+    },
+    adUnitPath() {
+      return `/${this.$adNetwork}/${this.adUnit}`
+    },
+    adOptDiv() {
+      return this.adUnitPath
+    },
+  },
+  beforeMount() {
+    if (!this.$adNetwork) {
+      throw new Error(
+        "GPT Ad network-code not found. Please provide network-code via plugin option or component's adNetwork props, see https://developers.google.com/doubleclick-gpt/guides/get-started"
+      )
+    }
+  },
   mounted() {
-    console.log(window.googletag)
+    window.googletag.cmd.push(() => {
+      this.adSlot = window.googletag
+        .defineSlot(this.adUnitPath, this.adSize, this.adOptDiv)
+        .addService(window.googletag.pubads())
+    })
+    window.googletag.cmd.push(() => {
+      window.googletag.display(this.adOptDiv)
+    })
+  },
+  beforeDestroy() {
+    window.googletag.cmd.push(() => {
+      window.googletag.destroySlots([this.adSlot])
+    })
   },
 }
 </script>
-
-<style land="scss" scoped></style>

--- a/plugins/gpt-ad/index.vue
+++ b/plugins/gpt-ad/index.vue
@@ -92,31 +92,31 @@ export default {
       window.googletag.cmd.push(() => {
         window.googletag.display(this.adOptDiv)
       })
-
-      // see: https://developers.google.com/doubleclick-gpt/reference#googletag.service-addeventlistenereventtype,-listener
-      window.googletag.cmd.push(() => {
-        const pubads = window.googletag.pubads()
-        const events = [
-          'slotRequested',
-          'slotRenderEnded',
-          'impressionViewable',
-          'slotOnload',
-          'slotVisibilityChanged',
-        ]
-        events.forEach((event) => {
-          pubads.addEventListener(event, (e) => {
-            if (e.slot === this.adSlot) {
-              this.$emit(event, e)
-            }
-          })
-        })
-      })
     } else {
       window.googletag.cmd.push(() => {
         this.adSlot = adSlot
         window.googletag.pubads().refresh([adSlot])
       })
     }
+
+    // see: https://developers.google.com/doubleclick-gpt/reference#googletag.service-addeventlistenereventtype,-listener
+    window.googletag.cmd.push(() => {
+      const pubads = window.googletag.pubads()
+      const events = [
+        'slotRequested',
+        'slotRenderEnded',
+        'impressionViewable',
+        'slotOnload',
+        'slotVisibilityChanged',
+      ]
+      events.forEach((event) => {
+        pubads.addEventListener(event, (e) => {
+          if (e.slot === this.adSlot) {
+            this.$emit(event, e)
+          }
+        })
+      })
+    })
   },
 }
 </script>

--- a/plugins/gpt-ad/index.vue
+++ b/plugins/gpt-ad/index.vue
@@ -55,15 +55,15 @@ export default {
     width() {
       switch (this.adSizeType) {
         case 'fixed': {
-          const x = this.adSize[0]
-          return `${x}px`
+          const width = this.adSize[0]
+          return `${width}px`
         }
         case 'multi': {
-          const xMax = this.adSize.reduce(
+          const widthMax = this.adSize.reduce(
             (acc, curr) => Math.max(curr[0], acc),
             0
           )
-          return `${xMax}px`
+          return `${widthMax}px`
         }
         case 'fluid':
         default:

--- a/plugins/gpt-ad/index.vue
+++ b/plugins/gpt-ad/index.vue
@@ -88,6 +88,7 @@ export default {
 
         this.$setGPTAdSlotsDefined(this.adOptDiv, this.adSlot)
       })
+
       window.googletag.cmd.push(() => {
         window.googletag.display(this.adOptDiv)
       })

--- a/plugins/gpt-ad/index.vue
+++ b/plugins/gpt-ad/index.vue
@@ -94,6 +94,7 @@ export default {
       })
     } else {
       window.googletag.cmd.push(() => {
+        this.adSlot = adSlot
         window.googletag.pubads().refresh([adSlot])
       })
     }

--- a/plugins/gpt-ad/index.vue
+++ b/plugins/gpt-ad/index.vue
@@ -1,0 +1,13 @@
+<template>
+  <div></div>
+</template>
+
+<script>
+export default {
+  mounted() {
+    console.log(window.googletag)
+  },
+}
+</script>
+
+<style land="scss" scoped></style>

--- a/plugins/gpt-ad/index.vue
+++ b/plugins/gpt-ad/index.vue
@@ -56,19 +56,23 @@ export default {
     }
   },
   mounted() {
-    window.googletag.cmd.push(() => {
-      this.adSlot = window.googletag
-        .defineSlot(this.adUnitPath, this.adSize, this.adOptDiv)
-        .addService(window.googletag.pubads())
-    })
-    window.googletag.cmd.push(() => {
-      window.googletag.display(this.adOptDiv)
-    })
-  },
-  beforeDestroy() {
-    window.googletag.cmd.push(() => {
-      window.googletag.destroySlots([this.adSlot])
-    })
+    const adSlot = this.$getGPTAdSlotsDefined(this.adOptDiv)
+    if (!adSlot) {
+      window.googletag.cmd.push(() => {
+        this.adSlot = window.googletag
+          .defineSlot(this.adUnitPath, this.adSize, this.adOptDiv)
+          .addService(window.googletag.pubads())
+
+        this.$setGPTAdSlotsDefined(this.adOptDiv, this.adSlot)
+      })
+      window.googletag.cmd.push(() => {
+        window.googletag.display(this.adOptDiv)
+      })
+    } else {
+      window.googletag.cmd.push(() => {
+        window.googletag.pubads().refresh([adSlot])
+      })
+    }
   },
 }
 </script>

--- a/plugins/gpt-ad/index.vue
+++ b/plugins/gpt-ad/index.vue
@@ -2,13 +2,14 @@
   <div
     :id="adOptDiv"
     :style="{
-      width: `${adSize[0]}px`,
-      height: `${adSize[1]}px`,
+      width: width,
     }"
   />
 </template>
 
 <script>
+import { getAdSizeType } from './util'
+
 export default {
   props: {
     adNetwork: {
@@ -22,6 +23,9 @@ export default {
     adSize: {
       type: Array,
       required: true,
+      validator(adSize) {
+        return getAdSizeType(adSize) !== undefined
+      },
     },
   },
   data() {
@@ -44,6 +48,27 @@ export default {
     },
     adOptDiv() {
       return this.adUnitPath
+    },
+    adSizeType() {
+      return getAdSizeType(this.adSize)
+    },
+    width() {
+      switch (this.adSizeType) {
+        case 'fixed': {
+          const x = this.adSize[0]
+          return `${x}px`
+        }
+        case 'multi': {
+          const xMax = this.adSize.reduce(
+            (acc, curr) => Math.max(curr[0], acc),
+            0
+          )
+          return `${xMax}px`
+        }
+        case 'fluid':
+        default:
+          return '100%'
+      }
     },
   },
   beforeMount() {

--- a/plugins/gpt-ad/index.vue
+++ b/plugins/gpt-ad/index.vue
@@ -2,7 +2,7 @@
   <div
     :id="adOptDiv"
     :style="{
-      width: width,
+      width: adWidth,
     }"
   />
 </template>
@@ -52,7 +52,7 @@ export default {
     adSizeType() {
       return getAdSizeType(this.adSize)
     },
-    width() {
+    adWidth() {
       switch (this.adSizeType) {
         case 'fixed': {
           const width = this.adSize[0]

--- a/plugins/gpt-ad/index.vue
+++ b/plugins/gpt-ad/index.vue
@@ -9,8 +9,6 @@
 </template>
 
 <script>
-import _ from 'lodash'
-
 export default {
   props: {
     adNetwork: {
@@ -24,12 +22,6 @@ export default {
     adSize: {
       type: Array,
       required: true,
-      validator(value) {
-        return (
-          value.length === 2 &&
-          value.reduce((acc, curr) => acc && _.isFinite(curr), true)
-        )
-      },
     },
   },
   data() {
@@ -41,8 +33,14 @@ export default {
     $adNetwork() {
       return this.adNetwork || this.adNetworkDefault
     },
+    $adUnit() {
+      if (this.mode === 'dev') {
+        return `test_${this.adUnit}`
+      }
+      return this.adUnit
+    },
     adUnitPath() {
-      return `/${this.$adNetwork}/${this.adUnit}`
+      return `/${this.$adNetwork}/${this.$adUnit}`
     },
     adOptDiv() {
       return this.adUnitPath

--- a/plugins/gpt-ad/util.js
+++ b/plugins/gpt-ad/util.js
@@ -32,6 +32,10 @@ export function getAdSizeType(adSize = []) {
   })
 
   function checkFixedSize(array = []) {
-    return array.length === 2 && _.isFinite(array[0]) && _.isFinite(array[1])
+    return (
+      array.length === 2 &&
+      Number.isFinite(array[0]) &&
+      Number.isFinite(array[1])
+    )
   }
 }

--- a/plugins/gpt-ad/util.js
+++ b/plugins/gpt-ad/util.js
@@ -1,5 +1,3 @@
-import _ from 'lodash'
-
 export function insertGPTScript() {
   const GPTScript = document.createElement('script')
   GPTScript.type = 'text/javascript'
@@ -14,22 +12,21 @@ export function getAdSizeType(adSize = []) {
    ** see: https://developers.google.com/doubleclick-gpt/guides/ad-sizes
    ** Ad size should be just ONE of these cases
    */
-  const sizes = {
-    fixed() {
+  const sizeValidators = [
+    function fixed() {
       return checkFixedSize(adSize)
     },
-    multi() {
+    function multi() {
       return adSize.every(checkFixedSize)
     },
-    fluid() {
+    function fluid() {
       return adSize.length === 1 && adSize[0] === 'fluid'
     },
-  }
+  ]
 
-  // output 'fixed', 'multi, 'fluid' or undefined
-  return _.findKey(sizes, function (validateTheType) {
-    return validateTheType()
-  })
+  return sizeValidators.find(function findTruth(validator) {
+    return validator()
+  }).name
 
   function checkFixedSize(array = []) {
     return (

--- a/plugins/gpt-ad/util.js
+++ b/plugins/gpt-ad/util.js
@@ -1,8 +1,37 @@
-export const insertGPTScript = function () {
+import _ from 'lodash'
+
+export const insertGPTScript = function insertGPTScript() {
   const GPTScript = document.createElement('script')
   GPTScript.type = 'text/javascript'
   GPTScript.async = true
   GPTScript.src = 'https://securepubads.g.doubleclick.net/tag/js/gpt.js'
   const head = document.getElementsByTagName('head')[0]
   head.appendChild(GPTScript)
+}
+
+export const getAdSizeType = function getAdSizeType(adSize = []) {
+  /*
+   ** see: https://developers.google.com/doubleclick-gpt/guides/ad-sizes
+   ** Ad size should be just ONE of there cases
+   */
+  const sizes = {
+    fixed() {
+      return checkFixedSize(adSize)
+    },
+    multi() {
+      return adSize.every(checkFixedSize)
+    },
+    fluid() {
+      return adSize.length === 1 && adSize[0] === 'fluid'
+    },
+  }
+
+  // output 'fixed', 'multi, 'fluid' or undefined
+  return _.findKey(sizes, function (validateTheType) {
+    return validateTheType()
+  })
+
+  function checkFixedSize(array = []) {
+    return array.length === 2 && _.isFinite(array[0]) && _.isFinite(array[1])
+  }
 }

--- a/plugins/gpt-ad/util.js
+++ b/plugins/gpt-ad/util.js
@@ -1,6 +1,6 @@
 import _ from 'lodash'
 
-export const insertGPTScript = function insertGPTScript() {
+export function insertGPTScript() {
   const GPTScript = document.createElement('script')
   GPTScript.type = 'text/javascript'
   GPTScript.async = true
@@ -9,7 +9,7 @@ export const insertGPTScript = function insertGPTScript() {
   head.appendChild(GPTScript)
 }
 
-export const getAdSizeType = function getAdSizeType(adSize = []) {
+export function getAdSizeType(adSize = []) {
   /*
    ** see: https://developers.google.com/doubleclick-gpt/guides/ad-sizes
    ** Ad size should be just ONE of these cases

--- a/plugins/gpt-ad/util.js
+++ b/plugins/gpt-ad/util.js
@@ -27,7 +27,7 @@ export function getAdSizeType(adSize = []) {
   // output 'fixed', 'multi, 'fluid' or undefined
   return sizeValidators.find(function findTruth(validator) {
     return validator()
-  }).name
+  })?.name
 
   function checkFixedSize(array = []) {
     return (

--- a/plugins/gpt-ad/util.js
+++ b/plugins/gpt-ad/util.js
@@ -1,0 +1,8 @@
+export const insertGPTScript = function () {
+  const GPTScript = document.createElement('script')
+  GPTScript.type = 'text/javascript'
+  GPTScript.async = true
+  GPTScript.src = 'https://securepubads.g.doubleclick.net/tag/js/gpt.js'
+  const head = document.getElementsByTagName('head')[0]
+  head.appendChild(GPTScript)
+}

--- a/plugins/gpt-ad/util.js
+++ b/plugins/gpt-ad/util.js
@@ -12,7 +12,7 @@ export const insertGPTScript = function insertGPTScript() {
 export const getAdSizeType = function getAdSizeType(adSize = []) {
   /*
    ** see: https://developers.google.com/doubleclick-gpt/guides/ad-sizes
-   ** Ad size should be just ONE of there cases
+   ** Ad size should be just ONE of these cases
    */
   const sizes = {
     fixed() {

--- a/plugins/gpt-ad/util.js
+++ b/plugins/gpt-ad/util.js
@@ -24,6 +24,7 @@ export function getAdSizeType(adSize = []) {
     },
   ]
 
+  // output 'fixed', 'multi, 'fluid' or undefined
   return sizeValidators.find(function findTruth(validator) {
     return validator()
   }).name

--- a/plugins/vuePluginsGlobal.client.js
+++ b/plugins/vuePluginsGlobal.client.js
@@ -1,6 +1,8 @@
 import Vue from 'vue'
 import GPTAD from './gpt-ad'
+import { GPT_MODE } from '~/configs/config'
 
 Vue.use(GPTAD, {
   adNetwork: '40175602',
+  mode: GPT_MODE,
 })

--- a/plugins/vuePluginsGlobal.client.js
+++ b/plugins/vuePluginsGlobal.client.js
@@ -1,0 +1,6 @@
+import Vue from 'vue'
+import GPTAD from './gpt-ad'
+
+Vue.use(GPTAD, {
+  adNetwork: '40175602',
+})

--- a/plugins/vuePluginsGlobal.js
+++ b/plugins/vuePluginsGlobal.js
@@ -1,6 +1,9 @@
 import Vue from 'vue'
 import VueLazyload from 'vue-lazyload'
+import GPTAD from './gpt-ad'
 import loading from '~/assets/loading.gif'
+
+Vue.use(GPTAD)
 
 Vue.use(VueLazyload, {
   loading,

--- a/plugins/vuePluginsGlobal.js
+++ b/plugins/vuePluginsGlobal.js
@@ -1,9 +1,6 @@
 import Vue from 'vue'
 import VueLazyload from 'vue-lazyload'
-import GPTAD from './gpt-ad'
 import loading from '~/assets/loading.gif'
-
-Vue.use(GPTAD)
 
 Vue.use(VueLazyload, {
   loading,


### PR DESCRIPTION
Vue plugin for [Google Publisher Tag](https://developers.google.com/doubleclick-gpt/guides/get-started)，此 plugin 會 install 一個 global component: GPTAD
- component mounted 前會 insert gpt.js external script，不需要手動全局引入額外的 script。
  - 我們可以透過 `v-if` 來控制是否需要 mount GPTAD component，達到按頁面需求 insert external script 的功能。
- [預設開啟 gpt ad lazy-loading 功能](https://developers.google.com/doubleclick-gpt/samples/lazy-loading)。

目前設計的使用方式如下，再請 @hsuehyungtan 和 @yeefun review:
```js
import Vue from 'vue'
import GPTAD from './gpt-ad'

Vue.use(GPTAD, {
  adNetwork: '40175602',
})
```
```vue
<template>
  <!-- gpt-ad plugin working in client side only -->
  <!-- use client-only wrapper to prevent SSR issue -->
  <client-only>
    <GPTAD
      :adUnit="'test_mirror_pc_fin_970x250_HD'"
      :adSize="[970, 250]"
    />
  </client-only>
</template>
```
