### PR TITLE
feat: add hasData validation for /tags api in fetchAPIData

### DIFF
--- a/plugins/requests/index.js
+++ b/plugins/requests/index.js
@@ -29,7 +29,8 @@ async function fetchAPIData(url) {
       (data.items && data.items.length > 0) ||
       (data.endpoints && Object.keys(data.endpoints).length > 0) ||
       // properties responsed by /search api
-      (data.hits && data.hits.total > 0)
+      (data.hits && data.hits.total > 0) ||
+      (url.startsWith('/tags') && data.id)
 
     if (hasData) {
       return data


### PR DESCRIPTION
目前的 [`/tags/:id` api response](http://104.199.190.189:8080/tags/581e9c0acb9d9e0e0023ecaa) 會無法通過 `hasData` 的檢查，所以會非預期的回報 Not Found error，故暫時先新增對於 tags endpoint 的通過條件。