### PR TITLE
feat(video): add video category page

### DIFF
--- a/components/UIVideoIframeWithItems.vue
+++ b/components/UIVideoIframeWithItems.vue
@@ -18,7 +18,7 @@
         :title="item.title"
         :href="`/video/${item.videoId}`"
         :imgSrc="item.thumbnails"
-        textPositionInMdViewport="right"
+        :textPositionInMdViewport="textPositionInMdViewport"
         class="video-iframe-items__item"
       />
     </div>
@@ -39,6 +39,10 @@ export default {
     items: {
       type: Array,
       required: true,
+    },
+    textPositionInMdViewport: {
+      type: String,
+      default: 'bottom',
     },
   },
   computed: {

--- a/pages/__tests__/category.video_coverstory.spec.js
+++ b/pages/__tests__/category.video_coverstory.spec.js
@@ -1,0 +1,49 @@
+import page from '../category/video_coverstory.vue'
+import createWrapperHelper from '~/test/helpers/createWrapperHelper'
+
+const createWrapper = createWrapperHelper()
+
+const sectionNameMock = 'video_coverstory'
+const playlistItemsMock = [
+  { videoId: 1 },
+  { videoId: 2 },
+  { videoId: 3 },
+  { videoId: 4 },
+  { videoId: 5 },
+  { videoId: 6 },
+]
+
+const wrapper = createWrapper(page, {
+  mocks: {
+    $route: {
+      path: `/category/${sectionNameMock}`,
+    },
+  },
+  data() {
+    return {
+      playlistItems: playlistItemsMock,
+    }
+  },
+})
+
+describe('computed data', () => {
+  test('should return proper categoryName', () => {
+    expect(wrapper.vm.categoryName).toBe(sectionNameMock)
+  })
+  test('should return proper firstFiveItems', () => {
+    const playlistItemsMock = [
+      { videoId: 1 },
+      { videoId: 2 },
+      { videoId: 3 },
+      { videoId: 4 },
+      { videoId: 5 },
+      { videoId: 6 },
+    ]
+    expect(wrapper.vm.firstFiveItems.length).toBe(5)
+    expect(wrapper.vm.firstFiveItems).toEqual(playlistItemsMock.slice(0, 5))
+  })
+  test('should return proper remainingItems', () => {
+    expect(wrapper.vm.remainingItems.length).toBe(playlistItemsMock.length - 5)
+    expect(wrapper.vm.remainingItems).toEqual(playlistItemsMock.slice(5))
+  })
+})

--- a/pages/category/video_coverstory.vue
+++ b/pages/category/video_coverstory.vue
@@ -1,0 +1,238 @@
+<template>
+  <section class="section">
+    <UIVideoIframeWithItems :items="playlistItems" class="section__highlight">
+      <template v-slot:heading>
+        <h1 :class="categoryName" class="section__heading">鏡封面</h1>
+      </template>
+    </UIVideoIframeWithItems>
+    <div class="section__remaining">
+      <UILinkedItemWithTitle
+        v-for="item in remainingItems"
+        :key="item.videoId"
+        :imgSrc="item.thumbnails"
+        :href="`/video/${item.videoId}`"
+        :title="item.title"
+        class="section__remaining-item"
+      />
+    </div>
+    <UIInfiniteLoading
+      v-if="shouldMountInfiniteLoading"
+      @infinite="infiniteHandler"
+    />
+  </section>
+</template>
+
+<script>
+import UIInfiniteLoading from '~/components/UIInfiniteLoading.vue'
+import UILinkedItemWithTitle from '~/components/UILinkedItemWithTitle.vue'
+import UIVideoIframeWithItems from '~/components/UIVideoIframeWithItems.vue'
+
+// temporary
+const PLAYLIST_MAPPING = {
+  // 鏡封面
+  video_coverstory: 'PLftq_bkhPR3ZtDGBhyqVGObQXazG_O3M3',
+  // 鏡娛樂
+  video_entertainment: 'PLftq_bkhPR3aj8UaqBvel6wia54AM5wlh',
+  // 鏡社會
+  video_society: 'PLftq_bkhPR3bLVBh5khl2pLxgFoPwrbfl',
+  // 鏡調查
+  video_investigation: 'PLftq_bkhPR3YOrSnIpcqSkY3hPE2TjXfW',
+  // 鏡財經
+  video_finance: 'PLftq_bkhPR3afBv0Wg_oUqjd_pkWIJm2h',
+  // 鏡人物
+  video_people: 'PLftq_bkhPR3YkNjH8VQZ__8nXZ9INIjAu',
+  // 鏡食旅
+  video_foodtravel: 'PLftq_bkhPR3baCfd6RU_1hbkY8ynXssun',
+  // 娛樂透視
+  video_ent_perspective: 'PLftq_bkhPR3YxUNEIHIMA2fsM-DqxCHMb',
+  // 鏡錶誌
+  // video_watch: '',
+  // 鏡車誌
+  // video_car: '',
+}
+
+export default {
+  name: 'CategoryVideo',
+  components: {
+    UIInfiniteLoading,
+    UILinkedItemWithTitle,
+    UIVideoIframeWithItems,
+  },
+  async fetch() {
+    const response = await this.fetchYoutubePlaylistItems()
+    this.setPlaylistItems(response)
+    this.nextPageToken = response.nextPageToken
+  },
+  data() {
+    return {
+      nextPageToken: '',
+      playlistItems: [],
+    }
+  },
+  computed: {
+    categoryName() {
+      return this.$route.path.split('/category/')[1]
+    },
+    firstFiveItems() {
+      return this.playlistItems.slice(0, 5)
+    },
+    remainingItems() {
+      return this.playlistItems.slice(5)
+    },
+    shouldMountInfiniteLoading() {
+      return this.nextPageToken
+    },
+  },
+  methods: {
+    fetchYoutubePlaylistItems(nextPageToken = '') {
+      return this.$fetchYoutubePlaylistItems({
+        playlistId: PLAYLIST_MAPPING[this.categoryName],
+        part: 'snippet',
+        maxResults: 15,
+        nextPageToken,
+      })
+    },
+    async infiniteHandler($state) {
+      try {
+        const response = await this.fetchYoutubePlaylistItems(
+          this.nextPageToken
+        )
+        this.setPlaylistItems(response)
+        this.nextPageToken = response.nextPageToken
+
+        if (this.nextPageToken) {
+          $state.complete()
+        } else {
+          $state.loaded()
+        }
+      } catch {
+        $state.error()
+      }
+    },
+    isValidYoutubeVideo(item) {
+      // for specific title from Youtube response data
+      const invalidTitles = ['Deleted video', 'Private video']
+      return !invalidTitles.includes(item.title)
+    },
+    processItems(response = {}) {
+      const items = response.items ?? []
+      return items.map(this.restructureItem).filter(this.isValidYoutubeVideo)
+    },
+    restructureItem(item) {
+      return {
+        videoId: item.id?.videoId || item.snippet?.resourceId?.videoId,
+        title: item.snippet?.title,
+        thumbnails: item.snippet?.thumbnails?.high?.url,
+      }
+    },
+    setPlaylistItems(reponse) {
+      this.playlistItems = [
+        ...this.playlistItems,
+        ...this.processItems(reponse),
+      ]
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.section {
+  padding: 30px 0 43px;
+  @include media-breakpoint-up(xl) {
+    width: calc(1024px + 15px);
+    margin: 0 auto;
+  }
+  &__highlight {
+    display: flex;
+    flex-direction: column;
+    @include media-breakpoint-up(xl) {
+      flex-direction: row;
+      flex-wrap: wrap;
+    }
+    &::v-deep {
+      .video-iframe-items__first {
+        order: 1;
+        margin-top: 20px;
+        @include media-breakpoint-up(xl) {
+          width: 460px;
+          margin-left: 7.5px;
+          border-bottom: 2px solid #979797;
+        }
+      }
+      .video-iframe-items__remaining {
+        order: 2;
+        margin-top: 20px;
+        @include media-breakpoint-up(md) {
+          display: flex;
+          flex-wrap: wrap;
+          width: 80%;
+          padding: 0;
+        }
+        @include media-breakpoint-up(xl) {
+          display: flex;
+          flex-wrap: wrap;
+          margin: 0 0 0 8.5px;
+        }
+        .video-iframe-items__item {
+          @include media-breakpoint-up(md) {
+            width: calc((100% - 60px) / 4);
+            margin: 20px 7.5px 0;
+          }
+          @include media-breakpoint-up(xl) {
+            width: calc((100% - 30px) / 2);
+          }
+        }
+      }
+    }
+  }
+  &__heading {
+    order: 0;
+    margin-top: 0;
+    @include media-breakpoint-up(xl) {
+      padding-left: 7.5px;
+    }
+    &::before {
+      content: '';
+      display: inline-block;
+      width: 10px;
+      height: 1em;
+      margin-right: 10px;
+      background-color: #000;
+      transform: translateY(4px);
+    }
+  }
+  &__remaining {
+    width: calc(100% - 40px);
+    margin: 0 auto;
+    @include media-breakpoint-up(md) {
+      display: flex;
+      flex-wrap: wrap;
+      width: 80%;
+    }
+    @include media-breakpoint-up(xl) {
+      width: auto;
+      margin-top: 30px;
+    }
+  }
+  &__remaining-item {
+    @include media-breakpoint-up(md) {
+      width: calc((100% - 60px) / 4);
+      margin: 20px 7.5px 0;
+    }
+    @include media-breakpoint-up(xl) {
+      width: calc((100% - 75px) / 5);
+    }
+    + .section__remaining-item {
+      margin-top: 20px;
+    }
+  }
+}
+
+.section__heading {
+  &.video_coverstory {
+    &::before {
+      background-color: #30bac8;
+    }
+  }
+}
+</style>

--- a/pages/category/video_coverstory.vue
+++ b/pages/category/video_coverstory.vue
@@ -101,9 +101,9 @@ export default {
         this.nextPageToken = response.nextPageToken
 
         if (this.nextPageToken) {
-          $state.complete()
-        } else {
           $state.loaded()
+        } else {
+          $state.complete()
         }
       } catch {
         $state.error()

--- a/pages/section/videohub.vue
+++ b/pages/section/videohub.vue
@@ -1,6 +1,10 @@
 <template>
   <section class="section">
-    <UIVideoIframeWithItems :items="latestData" class="section__latest">
+    <UIVideoIframeWithItems
+      :items="latestData"
+      textPositionInMdViewport="right"
+      class="section__latest"
+    >
       <template v-slot:heading>
         <h1>最新影片</h1>
       </template>


### PR DESCRIPTION
- 實作影音的 category 頁，目前只建立其中一個 category，其他 category 頁基本上邏輯都一樣，待未來 listing 頁重構後，一起進行規劃
- 影音頁共用的一些常數或方法，會在之後的 PR 重構拆出來，例如：`PLAYLIST_MAPPING `, `isValidYoutubeVideo` , `processItems ` , `restructureItem`