### PR TITLE
feat(microAd): add microAds on listing page (exclude topic listing)

### DIFF
--- a/components/MicroAd.vue
+++ b/components/MicroAd.vue
@@ -46,3 +46,68 @@ export default {
   },
 }
 </script>
+
+<style lang="scss" scoped>
+.micro-ad {
+  &::v-deep {
+    // Listing MicroAd Style
+    #compass-fit-widget-content {
+      .listArticleBlock__figure {
+        position: relative;
+        a {
+          display: block;
+          position: relative;
+          padding-top: 66.66%;
+          img {
+            position: absolute;
+            left: 0;
+            bottom: 0;
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+          }
+        }
+        .listArticleBlock__figure--colorBlock {
+          position: absolute;
+          left: 0;
+          bottom: 0;
+          padding: 8px;
+          line-height: 1;
+          font-size: 16px;
+          color: white;
+          display: inline-block;
+          max-width: 100%;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+      }
+      .listArticleBlock__content {
+        flex: 1 1 auto;
+        display: flex;
+        flex-direction: column;
+        padding: 15px 30px;
+        text-align: justify;
+        h2 {
+          color: #34495e;
+          font-size: 20.8px;
+          font-weight: 300;
+          line-height: 1.3;
+        }
+        p {
+          display: -webkit-box;
+          -webkit-box-orient: vertical;
+          margin: 10px 0 0 0;
+          color: #999;
+          font-size: 16px;
+          font-weight: 300;
+          line-height: 1.5;
+          word-wrap: break-word;
+          -webkit-line-clamp: 3;
+          overflow: hidden;
+        }
+      }
+    }
+  }
+}
+</style>

--- a/components/UIArticleList.vue
+++ b/components/UIArticleList.vue
@@ -9,22 +9,34 @@
       v-text="listTitle"
     />
     <ol v-if="showList" class="list-wrapper__list list">
-      <li v-for="item in listData" :key="item.id" class="list__list-item">
-        <UIArticleCard
-          :href="item.href"
-          :imgSrc="item.imgSrc"
-          :imgText="item.imgText"
-          :imgTextBackgroundColor="item.imgTextBackgroundColor"
-          :infoTitle="item.infoTitle"
-          :infoDescription="item.infoDescription"
-        />
-      </li>
+      <template v-for="(item, index) in listData">
+        <li :key="item.id" class="list__list-item">
+          <UIArticleCard
+            :href="item.href"
+            :imgSrc="item.imgSrc"
+            :imgText="item.imgText"
+            :imgTextBackgroundColor="item.imgTextBackgroundColor"
+            :infoTitle="item.infoTitle"
+            :infoDescription="item.infoDescription"
+          />
+        </li>
+        <li
+          v-if="needInsertMicroAd(index)"
+          :key="`microAd${index}`"
+          class="list__list-item"
+        >
+          <slot :name="getMicroAdSlotName(index)" />
+        </li>
+      </template>
     </ol>
   </section>
 </template>
 
 <script>
 import UIArticleCard from './UIArticleCard.vue'
+import microAdUnits from '~/constants/microAdUnits'
+
+const microAdUnitsKey = Object.keys(microAdUnits.LISTING)
 
 export default {
   components: {
@@ -45,12 +57,29 @@ export default {
       required: true,
     },
   },
+  data() {
+    return {
+      indexToMicroAdKey: {
+        1: microAdUnitsKey[0],
+        2: microAdUnitsKey[1],
+        5: microAdUnitsKey[2],
+      },
+    }
+  },
   computed: {
     showTitle() {
       return this.listTitle !== ''
     },
     showList() {
       return this.listData.length > 0
+    },
+  },
+  methods: {
+    needInsertMicroAd(index) {
+      return index === 1 || index === 2 || index === 5
+    },
+    getMicroAdSlotName(index) {
+      return this.indexToMicroAdKey[index]
     },
   },
 }

--- a/components/UIArticleList.vue
+++ b/components/UIArticleList.vue
@@ -21,11 +21,11 @@
           />
         </li>
         <li
-          v-if="needInsertMicroAd(index)"
+          v-if="needInsertMicroAdAfter(index)"
           :key="`microAd${index}`"
           class="list__list-item"
         >
-          <slot :name="getMicroAdSlotName(index)" />
+          <slot :name="getMicroAdSlotNameAfter(index)" />
         </li>
       </template>
     </ol>
@@ -75,10 +75,10 @@ export default {
     },
   },
   methods: {
-    needInsertMicroAd(index) {
+    needInsertMicroAdAfter(index) {
       return index === 1 || index === 2 || index === 5
     },
-    getMicroAdSlotName(index) {
+    getMicroAdSlotNameAfter(index) {
       return this.indexToMicroAdKey[index]
     },
   },

--- a/constants/microAdUnits.js
+++ b/constants/microAdUnits.js
@@ -1,0 +1,23 @@
+export default {
+  HOME: {
+    NA1_PC_HP: '4273362',
+    NA2_PC_HP: '4273366',
+    NA3_PC_HP: '4273370',
+    NA1_MB_HP: '4273363',
+    NA2_MB_HP: '4273367',
+    NA3_MB_HP: '4273371',
+  },
+  LISTING: {
+    NA1_RWD_SP: '4273364',
+    NA2_RWD_SP: '4273368',
+    NA3_RWD_SP: '4273372',
+  },
+  ARTICLE: {
+    NA1_PC_AP: '4276377',
+    NA2_PC_AP: '4276378',
+    NA3_PC_AP: '4276379',
+    NA1_MB_AP: '4273365',
+    NA2_MB_AP: '4273369',
+    NA3_MB_AP: '4273373',
+  },
+}

--- a/pages/author/_id.vue
+++ b/pages/author/_id.vue
@@ -12,7 +12,11 @@
       :listTitle="authorName"
       :listTitleColor="'#BCBCBC'"
       :listData="listDataFirstPage"
-    />
+    >
+      <template v-for="(unitId, key) in microAdUnits" v-slot:[key]>
+        <MicroAd :key="unitId" :unitId="unitId" />
+      </template>
+    </UIArticleList>
     <client-only>
       <GPTAD
         class="section__ad"
@@ -33,14 +37,17 @@
 </template>
 
 <script>
+import MicroAd from '~/components/MicroAd.vue'
 import UIArticleList from '~/components/UIArticleList.vue'
 import UIInfiniteLoading from '~/components/UIInfiniteLoading.vue'
 import styleVariables from '~/scss/_variables.scss'
 import gptUnits from '~/constants/gptUnits'
+import microAdUnits from '~/constants/microAdUnits'
 
 export default {
   name: 'Author',
   components: {
+    MicroAd,
     UIArticleList,
     UIInfiniteLoading,
   },
@@ -60,6 +67,7 @@ export default {
       listDataMaxResults: 12,
       listDataTotal: undefined,
       authorName: undefined,
+      microAdUnits: microAdUnits.LISTING,
     }
   },
   computed: {
@@ -188,6 +196,29 @@ export default {
   &__list {
     @include media-breakpoint-up(md) {
       margin: 8px 0 0 0;
+    }
+  }
+}
+
+.micro-ad {
+  height: 100%;
+  background-color: #f4f1e9;
+  box-shadow: 5px 5px 5px #bcbcbc;
+  @include media-breakpoint-up(xl) {
+    transition: all 0.3s ease-in-out;
+    &:hover {
+      transform: translateY(-20px);
+      box-shadow: 5px 15px 5px #bcbcbc;
+    }
+  }
+  &::v-deep {
+    #compass-fit-widget {
+      height: 100%;
+    }
+    #compass-fit-widget-content {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
     }
   }
 }

--- a/pages/category/_name.vue
+++ b/pages/category/_name.vue
@@ -12,7 +12,11 @@
       :listTitle="categoryTitle"
       :listTitleColor="sectionThemeColor"
       :listData="listDataFirstPage"
-    />
+    >
+      <template v-for="(unitId, key) in microAdUnits" v-slot:[key]>
+        <MicroAd :key="unitId" :unitId="unitId" />
+      </template>
+    </UIArticleList>
     <client-only>
       <GPTAD
         class="section__ad"
@@ -34,14 +38,17 @@
 
 <script>
 import { mapGetters } from 'vuex'
+import MicroAd from '~/components/MicroAd.vue'
 import UIArticleList from '~/components/UIArticleList.vue'
 import UIInfiniteLoading from '~/components/UIInfiniteLoading.vue'
 import styleVariables from '~/scss/_variables.scss'
 import gptUnits from '~/constants/gptUnits'
+import microAdUnits from '~/constants/microAdUnits'
 
 export default {
   name: 'Category',
   components: {
+    MicroAd,
     UIArticleList,
     UIInfiniteLoading,
   },
@@ -57,6 +64,7 @@ export default {
       listDataCurrentPage: 0,
       listDataMaxResults: 12,
       listDataTotal: undefined,
+      microAdUnits: microAdUnits.LISTING,
     }
   },
   computed: {
@@ -203,6 +211,29 @@ export default {
   &__list {
     @include media-breakpoint-up(md) {
       margin: 8px 0 0 0;
+    }
+  }
+}
+
+.micro-ad {
+  height: 100%;
+  background-color: #f4f1e9;
+  box-shadow: 5px 5px 5px #bcbcbc;
+  @include media-breakpoint-up(xl) {
+    transition: all 0.3s ease-in-out;
+    &:hover {
+      transform: translateY(-20px);
+      box-shadow: 5px 15px 5px #bcbcbc;
+    }
+  }
+  &::v-deep {
+    #compass-fit-widget {
+      height: 100%;
+    }
+    #compass-fit-widget-content {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
     }
   }
 }

--- a/pages/section/_name.vue
+++ b/pages/section/_name.vue
@@ -12,7 +12,11 @@
       :listTitle="currentSectionTitle"
       :listTitleColor="currentSectionThemeColor"
       :listData="listDataFirstPage"
-    />
+    >
+      <template v-for="(unitId, key) in microAdUnits" v-slot:[key]>
+        <MicroAd :key="unitId" :unitId="unitId" />
+      </template>
+    </UIArticleList>
     <client-only>
       <GPTAD
         class="section__ad"
@@ -34,14 +38,17 @@
 
 <script>
 import { mapState } from 'vuex'
+import MicroAd from '~/components/MicroAd.vue'
 import UIArticleList from '~/components/UIArticleList.vue'
 import UIInfiniteLoading from '~/components/UIInfiniteLoading.vue'
 import styleVariables from '~/scss/_variables.scss'
 import gptUnits from '~/constants/gptUnits'
+import microAdUnits from '~/constants/microAdUnits'
 
 export default {
   name: 'Section',
   components: {
+    MicroAd,
     UIArticleList,
     UIInfiniteLoading,
   },
@@ -57,6 +64,7 @@ export default {
       listDataCurrentPage: 0,
       listDataMaxResults: 12,
       listDataTotal: undefined,
+      microAdUnits: microAdUnits.LISTING,
     }
   },
   computed: {
@@ -188,6 +196,29 @@ export default {
   &__list {
     @include media-breakpoint-up(md) {
       margin: 8px 0 0 0;
+    }
+  }
+}
+
+.micro-ad {
+  height: 100%;
+  background-color: #f4f1e9;
+  box-shadow: 5px 5px 5px #bcbcbc;
+  @include media-breakpoint-up(xl) {
+    transition: all 0.3s ease-in-out;
+    &:hover {
+      transform: translateY(-20px);
+      box-shadow: 5px 15px 5px #bcbcbc;
+    }
+  }
+  &::v-deep {
+    #compass-fit-widget {
+      height: 100%;
+    }
+    #compass-fit-widget-content {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
     }
   }
 }

--- a/pages/tag/_id.vue
+++ b/pages/tag/_id.vue
@@ -12,7 +12,11 @@
       :listTitle="tagName"
       :listTitleColor="'#BCBCBC'"
       :listData="listDataFirstPage"
-    />
+    >
+      <template v-for="(unitId, key) in microAdUnits" v-slot:[key]>
+        <MicroAd :key="unitId" :unitId="unitId" />
+      </template>
+    </UIArticleList>
     <client-only>
       <GPTAD
         class="section__ad"
@@ -33,14 +37,17 @@
 </template>
 
 <script>
+import MicroAd from '~/components/MicroAd.vue'
 import UIArticleList from '~/components/UIArticleList.vue'
 import UIInfiniteLoading from '~/components/UIInfiniteLoading.vue'
 import styleVariables from '~/scss/_variables.scss'
 import gptUnits from '~/constants/gptUnits'
+import microAdUnits from '~/constants/microAdUnits'
 
 export default {
   name: 'Tag',
   components: {
+    MicroAd,
     UIArticleList,
     UIInfiniteLoading,
   },
@@ -60,6 +67,7 @@ export default {
       listDataMaxResults: 12,
       listDataTotal: undefined,
       tagName: undefined,
+      microAdUnits: microAdUnits.LISTING,
     }
   },
   computed: {
@@ -176,6 +184,29 @@ export default {
   &__list {
     @include media-breakpoint-up(md) {
       margin: 8px 0 0 0;
+    }
+  }
+}
+
+.micro-ad {
+  height: 100%;
+  background-color: #f4f1e9;
+  box-shadow: 5px 5px 5px #bcbcbc;
+  @include media-breakpoint-up(xl) {
+    transition: all 0.3s ease-in-out;
+    &:hover {
+      transform: translateY(-20px);
+      box-shadow: 5px 15px 5px #bcbcbc;
+    }
+  }
+  &::v-deep {
+    #compass-fit-widget {
+      height: 100%;
+    }
+    #compass-fit-widget-content {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
     }
   }
 }


### PR DESCRIPTION
雖然原本有提供 MicroAd 樣式，但未來樣式都會以寫在 `MicroAd.vue` 中為準，目前只加上 listing 原生廣告的樣式，而部分樣式仍然需要新增在所使用到 pages 中

就看你們對於 MicroAd 的設置，有沒有其他想法