### PR TITLE
feat(UIArticleList): render list item of MicroAd conditionally

### DIFF
--- a/components/UIArticleList.vue
+++ b/components/UIArticleList.vue
@@ -21,9 +21,12 @@
           />
         </li>
         <li
-          v-if="needInsertMicroAdAfter(index)"
+          v-if="
+            isSlotForMicroAd(getMicroAdSlotNameAfter(index)) &&
+            needInsertMicroAdAfter(index)
+          "
           :key="`microAd${index}`"
-          class="list__list-item"
+          class="list__list-item list__list-item--ad"
         >
           <slot :name="getMicroAdSlotNameAfter(index)" />
         </li>
@@ -80,6 +83,9 @@ export default {
     },
     getMicroAdSlotNameAfter(index) {
       return this.indexToMicroAdKey[index]
+    },
+    isSlotForMicroAd(unit) {
+      return Object.keys(this.$slots).includes(unit)
     },
   },
 }

--- a/components/__tests__/UIArticleList.spec.js
+++ b/components/__tests__/UIArticleList.spec.js
@@ -130,8 +130,6 @@ describe('MicroAd slot', function () {
       propsData: {
         listData,
       },
-
-      // This is intent to be an empty object
       slots: {
         NA1_RWD_SP: MicroAdMock,
         NA2_RWD_SP: MicroAdMock,

--- a/components/__tests__/UIArticleList.spec.js
+++ b/components/__tests__/UIArticleList.spec.js
@@ -1,4 +1,5 @@
 import { shallowMount } from '@vue/test-utils'
+import _ from 'lodash'
 import UIArticleList from '../UIArticleList.vue'
 import UIArticleCard from '../UIArticleCard.vue'
 
@@ -83,5 +84,71 @@ describe('render list items', () => {
     })
     const list = wrapper.find('ol')
     expect(list.exists()).toBe(false)
+  })
+})
+
+describe('MicroAd slot', function () {
+  test('Should not render list item of MicroAd if there are non of any slots exist', function () {
+    const listData = _.fill(Array(9), [
+      {
+        href: '/',
+        imgSrc: 'test imgSrc',
+        imgText: 'test imgText',
+        imgTextBackgroundColor: 'test imgTextBackgroundColor',
+        infoTitle: 'test infoTitle',
+        infoDescription: 'test infoDescription',
+      },
+    ])
+    const wrapper = shallowMount(UIArticleList, {
+      propsData: {
+        listData,
+      },
+      slots: {
+        RANDOM_SLOT_NAME_NO_MATCH_ANY_MICROAD: { template: '<div></div>' },
+      },
+    })
+    const listItemAds = wrapper.findAll('.list__list-item--ad')
+    expect(listItemAds).toHaveLength(0)
+  })
+  test('Should render list item of MicroAd if we use UIArticleList with MicroAd slot', function () {
+    const listData = _.fill(Array(9), [
+      {
+        href: '/',
+        imgSrc: 'test imgSrc',
+        imgText: 'test imgText',
+        imgTextBackgroundColor: 'test imgTextBackgroundColor',
+        infoTitle: 'test infoTitle',
+        infoDescription: 'test infoDescription',
+      },
+    ])
+    const MicroAdMock = {
+      template: `
+        <div></div>
+      `,
+    }
+    const wrapper = shallowMount(UIArticleList, {
+      propsData: {
+        listData,
+      },
+
+      // This is intent to be an empty object
+      slots: {
+        NA1_RWD_SP: MicroAdMock,
+        NA2_RWD_SP: MicroAdMock,
+        NA3_RWD_SP: MicroAdMock,
+      },
+    })
+
+    const listItems = wrapper.findAll('.list__list-item')
+    expect(listItems).toHaveLength(9 + 3)
+    expect(listItems.at(2).classes()).toContain('list__list-item--ad')
+    expect(listItems.at(2).find(MicroAdMock).exists()).toBe(true)
+    expect(listItems.at(4).classes()).toContain('list__list-item--ad')
+    expect(listItems.at(4).find(MicroAdMock).exists()).toBe(true)
+    expect(listItems.at(8).classes()).toContain('list__list-item--ad')
+    expect(listItems.at(8).find(MicroAdMock).exists()).toBe(true)
+
+    const listItemAds = wrapper.findAll('.list__list-item--ad')
+    expect(listItemAds).toHaveLength(3)
   })
 })


### PR DESCRIPTION
參考頁面：https://nuxt-dev.mirrormedia.mg/section/businessmoney

issue：
由於各 listing 頁 loadmore 至第二頁時，`UIArticleList` 並沒有將 MicroAd 塞入 slot，以至於會有預留給 MicroAd slot 的空洞。
所以我加上了判斷，若 `UIArticleList` 沒有使用任何 listing MicroAd named slot 時，則不 render 預留給 MicroAd 的 list item wrapper。並補上相關測試供參考。