### PR TITLE
fix: buttons do not have an accessible name

### DIFF
--- a/components/ContainerHeader.vue
+++ b/components/ContainerHeader.vue
@@ -1,7 +1,12 @@
 <template>
   <header>
     <div class="header-top-layer">
-      <button type="button" class="menu-icon" @click="handleClickMenuIcon" />
+      <button
+        type="button"
+        class="menu-icon"
+        aria-label="menu-icon"
+        @click="handleClickMenuIcon"
+      />
 
       <div class="logo-wrapper">
         <a href="/" class="logo" @click="sendHeaderGA('logo')">

--- a/components/UISearchBar.vue
+++ b/components/UISearchBar.vue
@@ -1,6 +1,11 @@
 <template>
   <div v-click-outside="hideField" class="search-bar">
-    <button type="button" class="search-icon" @click="toggleField" />
+    <button
+      type="button"
+      class="search-icon"
+      aria-label="search-icon"
+      @click="toggleField"
+    />
     <div v-show="shouldShowField" class="field">
       <UISearchBarSelect
         :options="options"


### PR DESCRIPTION
Fix the issue reported by Lighthouse.
https://web.dev/button-name/?utm_source=lighthouse&utm_medium=cli