### PR TITLE
fix: links to cross-origin destinations are unsafe

### DIFF
--- a/components/UIArticleListFocus.vue
+++ b/components/UIArticleListFocus.vue
@@ -6,7 +6,7 @@
           <a
             :href="$getHref(articleMain)"
             target="_blank"
-            rel="noopener"
+            rel="noopener noreferrer"
             @click="emitGA"
           >
             <img v-lazy="$getImage(articleMain, 'mobile')" alt="" />
@@ -20,7 +20,7 @@
           <a
             :href="$getHref(related)"
             target="_blank"
-            rel="noopener"
+            rel="noopener noreferrer"
             @click="emitGA"
           >
             <h1>{{ related.title }}</h1>

--- a/components/UIHeaderNavTopic.vue
+++ b/components/UIHeaderNavTopic.vue
@@ -23,6 +23,7 @@
           :key="subBrand.name"
           :href="subBrand.href"
           target="_blank"
+          rel="noopener noreferrer"
           @click="emitGA(`section ${subBrand.name}`)"
         >
           <img

--- a/components/UIOthersList.vue
+++ b/components/UIOthersList.vue
@@ -7,6 +7,7 @@
         :key="link.title"
         :href="link.href"
         target="_blank"
+        rel="noopener noreferrer"
         @click="emitGA(`more ${link.name}`)"
       >
         {{ link.title }}

--- a/components/UISidebar.vue
+++ b/components/UISidebar.vue
@@ -78,6 +78,7 @@
           :href="subBrand.href"
           target="_blank"
           class="section__title"
+          rel="noopener noreferrer"
           @click="emitGA(`section ${subBrand.name}`)"
         >
           {{ subBrand.title }}
@@ -91,6 +92,7 @@
         :key="other.name"
         :href="other.href"
         target="_blank"
+        rel="noopener noreferrer"
         @click="emitGA(`more ${other.name}`)"
       >
         {{ other.title }}
@@ -103,6 +105,7 @@
         :key="medium.name"
         :href="medium.href"
         target="_blank"
+        rel="noopener noreferrer"
         @click="emitGA(`social ${medium.name}`)"
       >
         <img

--- a/components/UIVideoCategory.vue
+++ b/components/UIVideoCategory.vue
@@ -4,6 +4,7 @@
       <a
         :href="`/video_category/${category.name}`"
         target="_blank"
+        rel="noopener noreferrer"
         v-text="category.title"
       />
     </h1>

--- a/components/UIYoutubePolicies.vue
+++ b/components/UIYoutubePolicies.vue
@@ -4,13 +4,21 @@
     <a
       href="https://developers.google.com/youtube/terms/developer-policies#definition-youtube-api-services"
       target="_blank"
+      rel="noopener noreferrer"
     >
       YouTube API 服務</a
     >，詳見
-    <a href="https://www.youtube.com/t/terms" target="_blank"
+    <a
+      href="https://www.youtube.com/t/terms"
+      target="_blank"
+      rel="noopener noreferrer"
       >YouTube 服務條款</a
     >、
-    <a href="https://policies.google.com/privacy" target="_blank">
+    <a
+      href="https://policies.google.com/privacy"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
       Google 隱私權與條款
     </a>
   </div>


### PR DESCRIPTION
Fix the issue reported by Lighthouse.
https://web.dev/external-anchors-use-rel-noopener/?utm_source=lighthouse&utm_medium=cli