### PR TITLE
fix: <html> element does not have a [lang] attribute

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -14,6 +14,9 @@ module.exports = {
    ** Headers of the page
    */
   head: {
+    htmlAttrs: {
+      lang: 'zh-Hant',
+    },
     title: SITE_TITLE,
     meta: [
       { charset: 'utf-8' },


### PR DESCRIPTION
Fix the issue reported by Lighthouse.
https://web.dev/html-has-lang/