### PR TITLE
refactor: extract social shares into composition functions

### DIFF
--- a/components/UIShareFacebook.vue
+++ b/components/UIShareFacebook.vue
@@ -1,6 +1,6 @@
 <template>
   <a
-    :href="`https://www.facebook.com/share.php?u=${shareUrl}`"
+    :href="sharedFbUrl"
     target="_blank"
     rel="noopener noreferrer"
     @click="$emit('click')"
@@ -20,26 +20,25 @@
 </template>
 
 <script>
+import { toRef } from '@nuxtjs/composition-api'
+import { useShareFb } from '~/composition/share.js'
+
 export default {
   name: 'UIShareFacebook',
+  setup(props) {
+    const sharedFbUrl = useShareFb(
+      props.url === undefined ? undefined : toRef(props, 'url')
+    )
+
+    return {
+      sharedFbUrl,
+    }
+  },
   props: {
     url: {
       type: String,
       default: undefined,
     },
-  },
-  data() {
-    return {
-      isMounted: false,
-    }
-  },
-  computed: {
-    shareUrl() {
-      return this.url || (this.isMounted && location.href)
-    },
-  },
-  mounted() {
-    this.isMounted = true
   },
 }
 </script>

--- a/components/UIShareLine.vue
+++ b/components/UIShareLine.vue
@@ -1,6 +1,6 @@
 <template>
   <a
-    :href="`https://social-plugins.line.me/lineit/share?url=${shareUrl}`"
+    :href="sharedLineUrl"
     target="_blank"
     rel="noopener noreferrer"
     @click="$emit('click')"
@@ -17,26 +17,25 @@
 </template>
 
 <script>
+import { toRef } from '@nuxtjs/composition-api'
+import { useShareLine } from '~/composition/share.js'
+
 export default {
   name: 'UIShareLine',
+  setup(props) {
+    const sharedLineUrl = useShareLine(
+      props.url === undefined ? undefined : toRef(props, 'url')
+    )
+
+    return {
+      sharedLineUrl,
+    }
+  },
   props: {
     url: {
       type: String,
       default: undefined,
     },
-  },
-  data() {
-    return {
-      isMounted: false,
-    }
-  },
-  computed: {
-    shareUrl() {
-      return encodeURIComponent(this.url || (this.isMounted && location.href))
-    },
-  },
-  mounted() {
-    this.isMounted = true
   },
 }
 </script>

--- a/components/__tests__/UIShareFacebook.spec.js
+++ b/components/__tests__/UIShareFacebook.spec.js
@@ -2,6 +2,7 @@ import UIShareFacebook from '../UIShareFacebook.vue'
 import createWrapperHelper from '~/test/helpers/createWrapperHelper'
 
 const createWrapper = createWrapperHelper()
+const fbSharedUrl = 'https://www.facebook.com/share.php?u='
 
 describe('href', () => {
   test('render the proper href', async () => {
@@ -15,22 +16,25 @@ describe('href', () => {
     const wrapper = createWrapper(UIShareFacebook)
     await wrapper.vm.$nextTick()
     const link = wrapper.get('a')
-    expect(link.attributes().href).toBe(
-      `https://www.facebook.com/share.php?u=${url}`
-    )
+    expect(link.attributes().href).toBe(`${fbSharedUrl}${url}`)
   })
 
-  test('render the proper href from props', () => {
-    const url = 'https://www.mirrormedia.mg/'
+  test('render the proper href from the prop "url"', async () => {
+    const mockUrl1 = 'https://www.mirrormedia.mg/'
+    const mockUrl2 = 'https://www.mirrormedia.mg/story/20200921ent009/'
     const wrapper = createWrapper(UIShareFacebook, {
       propsData: {
-        url,
+        url: mockUrl1,
       },
     })
+
     const link = wrapper.get('a')
-    expect(link.attributes().href).toBe(
-      `https://www.facebook.com/share.php?u=${url}`
-    )
+
+    expect(link.attributes().href).toBe(`${fbSharedUrl}${mockUrl1}`)
+
+    await wrapper.setProps({ url: mockUrl2 })
+
+    expect(link.attributes().href).toBe(`${fbSharedUrl}${mockUrl2}`)
   })
 })
 

--- a/components/__tests__/UIShareLine.spec.js
+++ b/components/__tests__/UIShareLine.spec.js
@@ -2,6 +2,7 @@ import UIShareLine from '../UIShareLine.vue'
 import createWrapperHelper from '~/test/helpers/createWrapperHelper'
 
 const createWrapper = createWrapperHelper()
+const lineSharedUrl = 'https://social-plugins.line.me/lineit/share?url='
 
 describe('href', () => {
   test('render the proper href', async () => {
@@ -16,24 +17,29 @@ describe('href', () => {
     await wrapper.vm.$nextTick()
     const link = wrapper.get('a')
     expect(link.attributes().href).toBe(
-      `https://social-plugins.line.me/lineit/share?url=${encodeURIComponent(
-        url
-      )}`
+      `${lineSharedUrl}${encodeURIComponent(url)}`
     )
   })
 
-  test('render the proper href from props', () => {
-    const url = 'https://www.mirrormedia.mg/'
+  test('render the proper href from the prop "url"', async () => {
+    const mockUrl1 = 'https://www.mirrormedia.mg/'
+    const mockUrl2 = 'https://www.mirrormedia.mg/story/20200921ent009/'
     const wrapper = createWrapper(UIShareLine, {
       propsData: {
-        url,
+        url: mockUrl1,
       },
     })
+
     const link = wrapper.get('a')
+
     expect(link.attributes().href).toBe(
-      `https://social-plugins.line.me/lineit/share?url=${encodeURIComponent(
-        url
-      )}`
+      `${lineSharedUrl}${encodeURIComponent(mockUrl1)}`
+    )
+
+    await wrapper.setProps({ url: mockUrl2 })
+
+    expect(link.attributes().href).toBe(
+      `${lineSharedUrl}${encodeURIComponent(mockUrl2)}`
     )
   })
 })

--- a/composition/share.js
+++ b/composition/share.js
@@ -1,0 +1,41 @@
+import { ref, computed, onMounted, isRef } from '@nuxtjs/composition-api'
+
+export { useShareFb, useShareLine }
+
+function useShareFb(url) {
+  let sharedUrl
+  const fbSharedUrl = 'https://www.facebook.com/share.php?u='
+
+  if (isRef(url)) {
+    sharedUrl = computed(() => `${fbSharedUrl}${url.value}`)
+  } else {
+    sharedUrl = ref('')
+
+    onMounted(function setSharedUrl() {
+      sharedUrl.value = `${fbSharedUrl}${url || window.location.href}`
+    })
+  }
+
+  return sharedUrl
+}
+
+function useShareLine(url) {
+  let sharedUrl
+  const lineSharedUrl = 'https://social-plugins.line.me/lineit/share?url='
+
+  if (isRef(url)) {
+    sharedUrl = computed(
+      () => `${lineSharedUrl}${encodeURIComponent(url.value)}`
+    )
+  } else {
+    sharedUrl = ref('')
+
+    onMounted(function setSharedUrl() {
+      sharedUrl.value = `${lineSharedUrl}${encodeURIComponent(
+        url || window.location.href
+      )}`
+    })
+  }
+
+  return sharedUrl
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
     '^~/(.*)$': '<rootDir>/$1',
     '^vue$': 'vue/dist/vue.common.js',
     '\\.css$': '<rootDir>/test/__mocks__/styleMock.js',
+    '@nuxtjs/composition-api': '@nuxtjs/composition-api/lib/cjs/entrypoint.js',
   },
   moduleFileExtensions: ['js', 'vue'],
   transform: {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -172,6 +172,7 @@ module.exports = {
    ** Nuxt.js dev-modules
    */
   buildModules: [
+    '@nuxtjs/composition-api',
     // Doc: https://github.com/nuxt-community/eslint-module
     '@nuxtjs/eslint-module',
     '@nuxtjs/style-resources',

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@mirror-media/nuxt-ssr-cache": "^1.6.1",
     "@nuxtjs/axios": "^5.12.2",
+    "@nuxtjs/composition-api": "^0.12.4",
     "@nuxtjs/dayjs": "^1.1.9",
     "axios": "^0.20.0",
     "body-parser": "^1.19.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2324,6 +2324,15 @@
     consola "^2.15.0"
     defu "^3.1.0"
 
+"@nuxtjs/composition-api@^0.12.4":
+  version "0.12.4"
+  resolved "https://registry.yarnpkg.com/@nuxtjs/composition-api/-/composition-api-0.12.4.tgz#332989de1ddd28dca8815103bee6afdd2b22864b"
+  integrity sha512-mgwfq3sHXWcWIyQrE3IqpUB26E77Jp2ON90YTlBy1i4leslJXqebX5i5vlaQAYq21WoUYxId4G/wxjTGEyHLVQ==
+  dependencies:
+    "@vue/composition-api" "1.0.0-beta.13"
+    defu "^3.1.0"
+    normalize-path "^3.0.0"
+
 "@nuxtjs/dayjs@^1.1.9":
   version "1.1.9"
   resolved "https://registry.yarnpkg.com/@nuxtjs/dayjs/-/dayjs-1.1.9.tgz#f957a3831aa41262fb31d18bf685d79ccc3233cf"
@@ -2699,6 +2708,13 @@
     vue-template-es2015-compiler "^1.9.0"
   optionalDependencies:
     prettier "^1.18.2"
+
+"@vue/composition-api@1.0.0-beta.13":
+  version "1.0.0-beta.13"
+  resolved "https://registry.yarnpkg.com/@vue/composition-api/-/composition-api-1.0.0-beta.13.tgz#441ffde5edfc0be90ae1fc96bebab70467762b51"
+  integrity sha512-5wHG9kfnTLST1rXFE5pHNL1VMl7Ojmr4WS1pIUmdkcPstBxr3/4fyRbYyeE4YUOJOnV7FkrSrPX69mIvApZeMA==
+  dependencies:
+    tslib "^2.0.1"
 
 "@vue/test-utils@^1.1.0":
   version "1.1.0"
@@ -12239,6 +12255,11 @@ tslib@^1.8.1, tslib@^1.9.0:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
+
+tslib@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
+  integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==
 
 tsutils@^3.17.1:
   version "3.17.1"


### PR DESCRIPTION
在做文章頁的浮動分享時，發現功能跟之前做的 `Share*` components 一樣，但樣式不同，而且牽扯到生命週期 `mounted`，難以抽取出來共用，因此就決定引進 Composition API，重構這個部分。

這一個 commit 只有重構，之後會把這裡的 composition functions 用在浮動分享上。