### PR TITLE
refactor: move MicroAd listing style to specific folder

### DIFF
--- a/components/MicroAd.vue
+++ b/components/MicroAd.vue
@@ -57,66 +57,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.micro-ad {
-  &::v-deep {
-    // Listing MicroAd Style
-    #compass-fit-widget-content {
-      .listArticleBlock__figure {
-        position: relative;
-        a {
-          display: block;
-          position: relative;
-          padding-top: 66.66%;
-          img {
-            position: absolute;
-            left: 0;
-            bottom: 0;
-            width: 100%;
-            height: 100%;
-            object-fit: cover;
-          }
-        }
-        .listArticleBlock__figure--colorBlock {
-          position: absolute;
-          left: 0;
-          bottom: 0;
-          padding: 8px;
-          line-height: 1;
-          font-size: 16px;
-          color: white;
-          display: inline-block;
-          max-width: 100%;
-          white-space: nowrap;
-          overflow: hidden;
-          text-overflow: ellipsis;
-        }
-      }
-      .listArticleBlock__content {
-        flex: 1 1 auto;
-        display: flex;
-        flex-direction: column;
-        padding: 15px 30px;
-        text-align: justify;
-        h2 {
-          color: #34495e;
-          font-size: 20.8px;
-          font-weight: 300;
-          line-height: 1.3;
-        }
-        p {
-          display: -webkit-box;
-          -webkit-box-orient: vertical;
-          margin: 10px 0 0 0;
-          color: #999;
-          font-size: 16px;
-          font-weight: 300;
-          line-height: 1.5;
-          word-wrap: break-word;
-          -webkit-line-clamp: 3;
-          overflow: hidden;
-        }
-      }
-    }
-  }
-}
+/**
+ * 請把樣式寫在 ~/css/micro-ad/ 資料夾中，再把樣式引入到需要它的元件內
+ */
 </style>

--- a/css/micro-ad/listing.scss
+++ b/css/micro-ad/listing.scss
@@ -1,0 +1,87 @@
+.micro-ad {
+  height: 100%;
+  background-color: #f4f1e9;
+  box-shadow: 5px 5px 5px #bcbcbc;
+  @include media-breakpoint-up(xl) {
+    transition: all 0.3s ease-in-out;
+
+    &:hover {
+      transform: translateY(-20px);
+      box-shadow: 5px 15px 5px #bcbcbc;
+    }
+  }
+
+  &::v-deep {
+    #compass-fit-widget {
+      height: 100%;
+    }
+
+    #compass-fit-widget-content {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+
+      .listArticleBlock__figure {
+        position: relative;
+
+        a {
+          display: block;
+          position: relative;
+          padding-top: 66.66%;
+
+          img {
+            position: absolute;
+            left: 0;
+            bottom: 0;
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+          }
+        }
+
+        .listArticleBlock__figure--colorBlock {
+          position: absolute;
+          left: 0;
+          bottom: 0;
+          padding: 8px;
+          line-height: 1;
+          font-size: 16px;
+          color: white;
+          display: inline-block;
+          max-width: 100%;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+      }
+
+      .listArticleBlock__content {
+        flex: 1 1 auto;
+        display: flex;
+        flex-direction: column;
+        padding: 15px 30px;
+        text-align: justify;
+
+        h2 {
+          color: #34495e;
+          font-size: 20.8px;
+          font-weight: 300;
+          line-height: 1.3;
+        }
+
+        p {
+          display: -webkit-box;
+          -webkit-box-orient: vertical;
+          margin: 10px 0 0 0;
+          color: #999;
+          font-size: 16px;
+          font-weight: 300;
+          line-height: 1.5;
+          word-wrap: break-word;
+          -webkit-line-clamp: 3;
+          overflow: hidden;
+        }
+      }
+    }
+  }
+}

--- a/pages/author/_id.vue
+++ b/pages/author/_id.vue
@@ -219,6 +219,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import '~/css/micro-ad/listing.scss';
+
 .section {
   background-color: #f2f2f2;
   padding: 36px 0;
@@ -236,29 +238,6 @@ export default {
   &__list {
     @include media-breakpoint-up(md) {
       margin: 8px 0 0 0;
-    }
-  }
-}
-
-.micro-ad {
-  height: 100%;
-  background-color: #f4f1e9;
-  box-shadow: 5px 5px 5px #bcbcbc;
-  @include media-breakpoint-up(xl) {
-    transition: all 0.3s ease-in-out;
-    &:hover {
-      transform: translateY(-20px);
-      box-shadow: 5px 15px 5px #bcbcbc;
-    }
-  }
-  &::v-deep {
-    #compass-fit-widget {
-      height: 100%;
-    }
-    #compass-fit-widget-content {
-      display: flex;
-      flex-direction: column;
-      height: 100%;
     }
   }
 }

--- a/pages/category/_name.vue
+++ b/pages/category/_name.vue
@@ -239,6 +239,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import '~/css/micro-ad/listing.scss';
+
 .section {
   background-color: #f2f2f2;
   padding: 36px 0;
@@ -256,29 +258,6 @@ export default {
   &__list {
     @include media-breakpoint-up(md) {
       margin: 8px 0 0 0;
-    }
-  }
-}
-
-.micro-ad {
-  height: 100%;
-  background-color: #f4f1e9;
-  box-shadow: 5px 5px 5px #bcbcbc;
-  @include media-breakpoint-up(xl) {
-    transition: all 0.3s ease-in-out;
-    &:hover {
-      transform: translateY(-20px);
-      box-shadow: 5px 15px 5px #bcbcbc;
-    }
-  }
-  &::v-deep {
-    #compass-fit-widget {
-      height: 100%;
-    }
-    #compass-fit-widget-content {
-      display: flex;
-      flex-direction: column;
-      height: 100%;
     }
   }
 }

--- a/pages/section/_name.vue
+++ b/pages/section/_name.vue
@@ -241,6 +241,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import '~/css/micro-ad/listing.scss';
+
 .section {
   background-color: #f2f2f2;
   padding: 36px 0;
@@ -258,29 +260,6 @@ export default {
   &__list {
     @include media-breakpoint-up(md) {
       margin: 8px 0 0 0;
-    }
-  }
-}
-
-.micro-ad {
-  height: 100%;
-  background-color: #f4f1e9;
-  box-shadow: 5px 5px 5px #bcbcbc;
-  @include media-breakpoint-up(xl) {
-    transition: all 0.3s ease-in-out;
-    &:hover {
-      transform: translateY(-20px);
-      box-shadow: 5px 15px 5px #bcbcbc;
-    }
-  }
-  &::v-deep {
-    #compass-fit-widget {
-      height: 100%;
-    }
-    #compass-fit-widget-content {
-      display: flex;
-      flex-direction: column;
-      height: 100%;
     }
   }
 }

--- a/pages/section/topic.vue
+++ b/pages/section/topic.vue
@@ -199,6 +199,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import '~/css/micro-ad/listing.scss';
+
 .section {
   background-color: #f2f2f2;
   padding: 36px 0;
@@ -216,29 +218,6 @@ export default {
   &__list {
     @include media-breakpoint-up(md) {
       margin: 8px 0 0 0;
-    }
-  }
-}
-
-.micro-ad {
-  height: 100%;
-  background-color: #f4f1e9;
-  box-shadow: 5px 5px 5px #bcbcbc;
-  @include media-breakpoint-up(xl) {
-    transition: all 0.3s ease-in-out;
-    &:hover {
-      transform: translateY(-20px);
-      box-shadow: 5px 15px 5px #bcbcbc;
-    }
-  }
-  &::v-deep {
-    #compass-fit-widget {
-      height: 100%;
-    }
-    #compass-fit-widget-content {
-      display: flex;
-      flex-direction: column;
-      height: 100%;
     }
   }
 }

--- a/pages/tag/_id.vue
+++ b/pages/tag/_id.vue
@@ -207,6 +207,8 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import '~/css/micro-ad/listing.scss';
+
 .section {
   background-color: #f2f2f2;
   padding: 36px 0;
@@ -224,29 +226,6 @@ export default {
   &__list {
     @include media-breakpoint-up(md) {
       margin: 8px 0 0 0;
-    }
-  }
-}
-
-.micro-ad {
-  height: 100%;
-  background-color: #f4f1e9;
-  box-shadow: 5px 5px 5px #bcbcbc;
-  @include media-breakpoint-up(xl) {
-    transition: all 0.3s ease-in-out;
-    &:hover {
-      transform: translateY(-20px);
-      box-shadow: 5px 15px 5px #bcbcbc;
-    }
-  }
-  &::v-deep {
-    #compass-fit-widget {
-      height: 100%;
-    }
-    #compass-fit-widget-content {
-      display: flex;
-      flex-direction: column;
-      height: 100%;
     }
   }
 }


### PR DESCRIPTION
把 `MicroAd` 的樣式移到 `~/css/micro-ad/` 資料夾中，需要的組件再分別引入，原因有三：
- 避免樣式衝突。
- 方便管理。
- 只引入需要的樣式，縮減頁面 CSS 檔案大小。