### PR TITLE
style: lint comments style

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,7 @@
-/*
- ** for test ONLY
- ** to customize Babel configuration for development or production, please use build.babel in nuxt.config.js
- ** https://nuxtjs.org/api/configuration-build/#babel
+/**
+ * for test ONLY
+ * to customize Babel configuration for development or production, please use build.babel in nuxt.config.js
+ * https://nuxtjs.org/api/configuration-build/#babel
  */
 {
   "env": {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,9 +15,42 @@ module.exports = {
     'plugin:nuxt/recommended',
   ],
   plugins: ['prettier'],
+
   // add your custom rules here
   rules: {
     'nuxt/no-cjs-in-config': 'off',
     'vue/attribute-hyphenation': ['error', 'never'],
+
+    /**
+     * Comments 規範參考自 https://github.com/airbnb/javascript#comments
+     */
+    'multiline-comment-style': ['warn', 'starred-block'],
+    'lines-around-comment': [
+      'warn',
+      {
+        beforeLineComment: true,
+        allowBlockStart: true,
+        allowObjectStart: true,
+        allowArrayStart: true,
+        allowClassStart: true,
+      },
+    ],
+
+    // https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/style.js#L504-L516
+    'spaced-comment': [
+      'error',
+      'always',
+      {
+        line: {
+          exceptions: ['-', '+'],
+          markers: ['=', '!', '/'], // space here to support sprockets directives, slash for TS /// comments
+        },
+        block: {
+          exceptions: ['-', '+'],
+          markers: ['=', '!', ':', '::'], // space here to support sprockets directives and flow comment types
+          balanced: true,
+        },
+      },
+    ],
   },
 }

--- a/components/ContainerFullScreenAds.vue
+++ b/components/ContainerFullScreenAds.vue
@@ -43,27 +43,27 @@
 import UIFullScreenAd from '~/components/UIFullScreenAd.vue'
 import ContainerGptAd from '~/components/ContainerGptAd.vue'
 
-/*
-  蓋板廣告有三層，分別為：第一層 FS、第二層 AD2、第三層 Innity
-  
-  第一層 FS（AdFirst）：
-  帶有自定義的樣式和關閉按鈕，關閉按鈕在發送廣告請求後，延遲 3 秒才顯示
-  因為帶有自定義的透明灰底樣式，所以在廣告載入結束後才顯示（isAdFirstVisible）
-  若沒有 FS 則顯示下一層 AD2 廣告
-
-  第二層 AD2（AdSecond）:
-  AD2 為不額外帶有樣式的廣告，但因為 GPT Lazy loading 需要知道何時載入的位置
-  因此需要設置修正用樣式（hasModifiedStyle），來觸發廣告載入
-  當廣告載入完成後，就將該樣式移除
-
-  而 AD2 無法透過 GPT 的事件來確認是否有廣告，跟廠商協調後
-  當 AD2 沒廣告時，由廠商傳遞 noad2 事件，由我們監聽來顯示下一層 Innity 廣告
-
-  第三層 Innity（AdThird）:
-  同 AD2 一樣為不額外帶有樣式的廣告，因此需要先設置修正用樣式
-
-  ＊ APP 用頁面沒有蓋板廣告
-*/
+/**
+ * 蓋板廣告有三層，分別為：第一層 FS、第二層 AD2、第三層 Innity
+ *
+ * 第一層 FS（AdFirst）：
+ * 帶有自定義的樣式和關閉按鈕，關閉按鈕在發送廣告請求後，延遲 3 秒才顯示
+ * 因為帶有自定義的透明灰底樣式，所以在廣告載入結束後才顯示（isAdFirstVisible）
+ * 若沒有 FS 則顯示下一層 AD2 廣告
+ *
+ * 第二層 AD2（AdSecond）:
+ * AD2 為不額外帶有樣式的廣告，但因為 GPT Lazy loading 需要知道何時載入的位置
+ * 因此需要設置修正用樣式（hasModifiedStyle），來觸發廣告載入
+ * 當廣告載入完成後，就將該樣式移除
+ *
+ * 而 AD2 無法透過 GPT 的事件來確認是否有廣告，跟廠商協調後
+ * 當 AD2 沒廣告時，由廠商傳遞 noad2 事件，由我們監聽來顯示下一層 Innity 廣告
+ *
+ * 第三層 Innity（AdThird）:
+ * 同 AD2 一樣為不額外帶有樣式的廣告，因此需要先設置修正用樣式
+ *
+ * ＊ APP 用頁面沒有蓋板廣告
+ */
 
 export default {
   name: 'ContainerFullScreenAds',
@@ -94,8 +94,10 @@ export default {
     },
   },
   mounted() {
-    // AD2 無法透過 GPT 的事件來確認是否有廣告，需要透過此事件來確認
-    // 因為 this 綁定對象關係，使用 =>
+    /**
+     * AD2 無法透過 GPT 的事件來確認是否有廣告，需要透過此事件來確認
+     * 因為 this 綁定對象關係，使用 =>
+     */
     window.addEventListener('noad2', () => {
       this.hasModifiedStyle = true
       this.hasAdSecond = false

--- a/components/ContainerHeader.vue
+++ b/components/ContainerHeader.vue
@@ -214,6 +214,7 @@ export default {
     },
     activeTheNavSection(path) {
       const regexWithPrefixOfStory = this.generateRegexWithPrefixOf('/story/')
+
       // 文章頁也需要設定 sectionName，但不是在這邊做，而需移到 story page，故 return
       if (this.hasPrefix(path, regexWithPrefixOfStory)) {
         return

--- a/components/UISearchBar.vue
+++ b/components/UISearchBar.vue
@@ -85,10 +85,10 @@ export default {
     display: block;
     position: absolute;
     top: -12px;
-    /*
-      5% = (100% - 90%) / 2
-      3.5 = (18 - 11) / 2
-    */
+    /**
+     * 5% = (100% - 90%) / 2
+     * 3.5 = (18 - 11) / 2
+     */
     right: calc(5% + 3.5px);
     border-color: transparent transparent #064f77;
     border-style: solid;

--- a/components/UISearchBarWrapper.vue
+++ b/components/UISearchBarWrapper.vue
@@ -48,13 +48,16 @@ export default {
       const keyword = this.handleWhitespace(this.keyword)
       const { id } = this.selectedOption
       const query = id ? `?section=${id}` : ''
+
       // this.$router.push(`/search/${keyword}${query}`)
       location.assign(`/search/${keyword}${query}`)
     },
     handleWhitespace(str) {
-      // 1. remove whitespace from both sides of a string
-      // 2. remove whitespace from both sides of any comma
-      // 3. replace whitespace bwtween two letters with a comma
+      /**
+       * 1. remove whitespace from both sides of a string
+       * 2. remove whitespace from both sides of any comma
+       * 3. replace whitespace bwtween two letters with a comma
+       */
       return str
         .trim()
         .replace(/\s*,\s*/g, ',')

--- a/components/UIYoutubeSubscribe.vue
+++ b/components/UIYoutubeSubscribe.vue
@@ -1,3 +1,6 @@
+<!--
+  Document: https://developers.google.com/youtube/youtube_subscribe_button
+-->
 <template>
   <lazy-component @show="init">
     <!-- "g-ytsubscribe" is a required class setting by youtube, do not remove. -->
@@ -11,8 +14,6 @@
 </template>
 
 <script>
-// Document: https://developers.google.com/youtube/youtube_subscribe_button
-
 export default {
   name: 'UIYoutubeSubscribe',
   props: {

--- a/components/__tests__/UIArticleListFocus.spec.js
+++ b/components/__tests__/UIArticleListFocus.spec.js
@@ -41,6 +41,7 @@ describe('main article', () => {
     const wrapper = createWrapper(UIArticleListFocus)
 
     const mainLink = wrapper.get(`[href="/story/${mockAricleMain.slug}/"]`)
+
     // expect(mainLink.get('img').attributes().src).toBe(
     //   mockAricleMain.heroImage.image.resizedTargets.mobile.url
     // )

--- a/components/__tests__/UISearchBarWrapper.spec.js
+++ b/components/__tests__/UISearchBarWrapper.spec.js
@@ -50,6 +50,7 @@ describe('search feature', () => {
     }
 
     searchBarVM.$emit('search')
+
     // expect($router.push).toBeCalledWith('/search/明星')
     expect(window.location.assign).toBeCalledWith('/search/明星')
 
@@ -58,6 +59,7 @@ describe('search feature', () => {
       keyword: '',
     })
     searchBarVM.$emit('search')
+
     // expect($router.push).not.toBeCalled()
     expect(window.location.assign).not.toBeCalled()
 
@@ -66,6 +68,7 @@ describe('search feature', () => {
       keyword: '明星 媒體',
     })
     searchBarVM.$emit('search')
+
     // expect($router.push).toBeCalledWith('/search/明星,媒體')
     expect(window.location.assign).toBeCalledWith('/search/明星,媒體')
 
@@ -74,6 +77,7 @@ describe('search feature', () => {
       keyword: ' 明星  媒體   ',
     })
     searchBarVM.$emit('search')
+
     // expect($router.push).toBeCalledWith('/search/明星,媒體')
     expect(window.location.assign).toBeCalledWith('/search/明星,媒體')
 
@@ -82,6 +86,7 @@ describe('search feature', () => {
       keyword: '明星, 媒體',
     })
     searchBarVM.$emit('search')
+
     // expect($router.push).toBeCalledWith('/search/明星,媒體')
     expect(window.location.assign).toBeCalledWith('/search/明星,媒體')
 
@@ -90,6 +95,7 @@ describe('search feature', () => {
       selectedOption: { title: '娛樂', id: '57e1e11cee85930e00cad4ea' },
     })
     searchBarVM.$emit('search')
+
     // expect($router.push).toBeCalledWith(
     //   '/search/明星,媒體?section=57e1e11cee85930e00cad4ea'
     // )

--- a/components/audio-player/__tests__/ContainerAudioPlayer.spec.js
+++ b/components/audio-player/__tests__/ContainerAudioPlayer.spec.js
@@ -142,6 +142,7 @@ describe('audio status', () => {
     const mockCurrentTime = 3
 
     audio.currentTime = mockCurrentTime
+
     // 避免 UIAudioPlayerBar 針對 prop 'value' 自定義的 validator 檢查失敗
     audioStatus.duration = 6
 

--- a/constants/index.js
+++ b/constants/index.js
@@ -93,20 +93,28 @@ const SUB_BRAND_LINKS = [MIRRORVOICE_LINK, MIRRORFICTION_LINK, READR_LINK]
 const VIDEOHUB_CATEGORIES_PLAYLIST_MAPPING = {
   // 鏡封面
   video_coverstory: 'PLftq_bkhPR3ZtDGBhyqVGObQXazG_O3M3',
+
   // 鏡娛樂
   video_entertainment: 'PLftq_bkhPR3aj8UaqBvel6wia54AM5wlh',
+
   // 鏡社會
   video_society: 'PLftq_bkhPR3bLVBh5khl2pLxgFoPwrbfl',
+
   // 鏡調查
   video_investigation: 'PLftq_bkhPR3YOrSnIpcqSkY3hPE2TjXfW',
+
   // 鏡人物
   video_people: 'PLftq_bkhPR3YkNjH8VQZ__8nXZ9INIjAu',
+
   // 鏡財經
   video_finance: 'PLftq_bkhPR3afBv0Wg_oUqjd_pkWIJm2h',
+
   // 鏡食旅
   video_foodtravel: 'PLftq_bkhPR3baCfd6RU_1hbkY8ynXssun',
+
   // 娛樂透視
   video_ent_perspective: 'PLftq_bkhPR3YxUNEIHIMA2fsM-DqxCHMb',
+
   // 鏡錶誌
   video_carandwatch: 'PLgvIJQ8OtT8LOdwVF4P9hdQiuf6uAiwb6',
 }

--- a/deprecated/kc-scroll.js
+++ b/deprecated/kc-scroll.js
@@ -9,10 +9,12 @@ function currentYPosition() {
   if (self.pageYOffset) {
     return self.pageYOffset
   }
+
   // Internet Explorer 6 - standards mode
   if (document.documentElement && document.documentElement.scrollTop) {
     return document.documentElement.scrollTop
   }
+
   // Internet Explorer 6, 7 and 8
   if (document.body.scrollTop) {
     return document.body.scrollTop
@@ -52,12 +54,14 @@ function smoothScrollTo({ eID, yPos, steps }) {
     return
   }
   let speed = Math.round(distance / 50)
+
   // do scrollTo after every single 'speed'
   if (speed > 20) speed = 20
   if (speed < 10) speed = 10
 
   const _stepTimes = steps !== null && steps !== undefined ? steps : 25
   const step = Math.round(distance / _stepTimes)
+
   // do scrollTo for every 'step'px for 25 times
   let leapY = stopY > startY ? startY + step : startY - step
   let timer = 1
@@ -289,7 +293,7 @@ class OnePageScroller {
           default:
             return
         }
-        // }
+
         return false
       }
       this.doc.onkeydown = _keydownHandler

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -8,8 +8,8 @@ const FB_APP_ID = '175313259598308'
 const FB_PAGE_ID = '1855418728011324'
 
 module.exports = {
-  /*
-   ** Headers of the page
+  /**
+   * Headers of the page
    */
   head: {
     htmlAttrs: {
@@ -140,16 +140,19 @@ module.exports = {
       },
     ],
   },
-  /*
-   ** Customize the progress-bar color
+
+  /**
+   * Customize the progress-bar color
    */
   loading: { color: '#fff' },
-  /*
-   ** Global CSS
+
+  /**
+   * Global CSS
    */
   css: ['~/css/base.css', 'swiper/css/swiper.css'],
-  /*
-   ** Plugins to load before mounting the App
+
+  /**
+   * Plugins to load before mounting the App
    */
   plugins: [
     '~/plugins/vuePluginsGlobal.js',
@@ -159,8 +162,9 @@ module.exports = {
     '~/plugins/article/index.js',
     '~/plugins/user-behavior-log/index.client.js',
   ],
-  /*
-   ** Nuxt.js Server Middleware
+
+  /**
+   * Nuxt.js Server Middleware
    */
   serverMiddleware: [
     '~/api/headers.js',
@@ -178,17 +182,20 @@ module.exports = {
     },
     { path: '/api', handler: '~/api/index.js' },
   ],
-  /*
-   ** Nuxt.js dev-modules
+
+  /**
+   * Nuxt.js dev-modules
    */
   buildModules: [
     '@nuxtjs/composition-api',
+
     // Doc: https://github.com/nuxt-community/eslint-module
     '@nuxtjs/eslint-module',
     '@nuxtjs/style-resources',
-    /*
-     ** googleAnalytics module configuration
-     ** https://github.com/nuxt-community/analytics-module
+
+    /**
+     * googleAnalytics module configuration
+     * https://github.com/nuxt-community/analytics-module
      */
     [
       '@nuxtjs/google-analytics',
@@ -202,8 +209,9 @@ module.exports = {
     ],
     '@nuxtjs/svg',
   ],
-  /*
-   ** Nuxt.js modules
+
+  /**
+   * Nuxt.js modules
    */
   modules: [
     // Doc: https://axios.nuxtjs.org/usage
@@ -214,11 +222,12 @@ module.exports = {
       ? ['@mirror-media/nuxt-ssr-cache']
       : []),
   ],
+
   // config for @mirror-media/nuxt-ssr-cache
   cache: {
-    /*
-     ** Workaround, pages array must exist and not empty,
-     ** see: https://github.com/arash16/nuxt-ssr-cache/blob/master/src/middleware.js#L34
+    /**
+     * Workaround, pages array must exist and not empty,
+     * see: https://github.com/arash16/nuxt-ssr-cache/blob/master/src/middleware.js#L34
      */
     pages: ['/'],
 
@@ -238,10 +247,11 @@ module.exports = {
     },
     store: {
       type: 'redis',
-      /*
-       ** readHost and writeHost working in @mirror-media/nuxt-ssr-cache only,
-       ** for redis write/read master-slave replication
-       ** Not working in the original nuxt-ssr-cache package
+
+      /**
+       * readHost and writeHost working in @mirror-media/nuxt-ssr-cache only,
+       * for redis write/read master-slave replication
+       * Not working in the original nuxt-ssr-cache package
        */
       readHost: require('./configs/config').REDIS_READ_HOST,
       writeHost: require('./configs/config').REDIS_WRITE_HOST,
@@ -250,16 +260,18 @@ module.exports = {
       ttl: 60 * 5,
     },
   },
-  /*
-   ** Axios module configuration
-   ** See https://axios.nuxtjs.org/options
+
+  /**
+   * Axios module configuration
+   * See https://axios.nuxtjs.org/options
    */
   axios: {},
   styleResources: {
     scss: '~/scss/*.scss',
   },
-  /*
-   ** Build configuration
+
+  /**
+   * Build configuration
    */
   build: {
     babel: {
@@ -268,8 +280,9 @@ module.exports = {
         options.corejs = { version: 3, proposals: true }
       },
     },
-    /*
-     ** You can extend webpack config here
+
+    /**
+     * You can extend webpack config here
      */
     extend(config, ctx) {
       config.resolve.extensions = ['.js']
@@ -284,9 +297,10 @@ module.exports = {
       }
     },
   },
-  /*
-   ** Nuxt Telemetry configuration
-   ** Doc: https://github.com/nuxt/telemetry#opting-out
+
+  /**
+   * Nuxt Telemetry configuration
+   * Doc: https://github.com/nuxt/telemetry#opting-out
    */
   telemetry: false,
 }

--- a/pages/__tests__/search.spec.js
+++ b/pages/__tests__/search.spec.js
@@ -82,6 +82,7 @@ describe('section data', () => {
     })
     expect(wrapper.vm.sectionQueryTitle).toBe(sectionTitleMock)
   })
+
   // test('section title should be null if section query in url not exist', () => {
   //   const wrapper = createWrapper(page)
   //   expect(wrapper.vm.sectionQueryTitle).toBe(null)

--- a/pages/author/_id.vue
+++ b/pages/author/_id.vue
@@ -96,9 +96,11 @@ export default {
       return Math.ceil(this.listDataTotal / this.listDataMaxResults)
     },
 
-    // Constraint which prevent loadmore unexpectly
-    // if we navigating on client-side
-    // due to the list data of the first page has not been loaded.
+    /**
+     * Constraint which prevent loadmore unexpectly
+     * if we navigating on client-side
+     * due to the list data of the first page has not been loaded.
+     */
     shouldMountInfiniteLoading() {
       return this.listDataCurrentPage >= 1
     },

--- a/pages/category/_name.vue
+++ b/pages/category/_name.vue
@@ -127,9 +127,11 @@ export default {
       return Math.ceil(this.listDataTotal / this.listDataMaxResults)
     },
 
-    // Constraint which prevent loadmore unexpectly
-    // if we navigating on client-side
-    // due to the list data of the first page has not been loaded.
+    /**
+     * Constraint which prevent loadmore unexpectly
+     * if we navigating on client-side
+     * due to the list data of the first page has not been loaded.
+     */
     shouldMountInfiniteLoading() {
       return this.listDataCurrentPage >= 1
     },

--- a/pages/search/_keyword.vue
+++ b/pages/search/_keyword.vue
@@ -58,9 +58,12 @@ export default {
       }
       return Math.ceil(this.listDataTotal / this.listDataMaxResults)
     },
-    // Constraint which prevent loadmore unexpectedly
-    // if we navigating on client-side
-    // due to the list data of the first page has not been loaded.
+
+    /**
+     * Constraint which prevent loadmore unexpectedly
+     * if we navigating on client-side
+     * due to the list data of the first page has not been loaded.
+     */
     shouldMountInfiniteLoading() {
       return this.listDataCurrentPage >= 1
     },

--- a/pages/section/_name.vue
+++ b/pages/section/_name.vue
@@ -112,9 +112,11 @@ export default {
       return Math.ceil(this.listDataTotal / this.listDataMaxResults)
     },
 
-    // Constraint which prevent loadmore unexpectly
-    // if we navigating on client-side
-    // due to the list data of the first page has not been loaded.
+    /**
+     * Constraint which prevent loadmore unexpectly
+     * if we navigating on client-side
+     * due to the list data of the first page has not been loaded.
+     */
     shouldMountInfiniteLoading() {
       return this.listDataCurrentPage >= 1
     },

--- a/pages/section/topic.vue
+++ b/pages/section/topic.vue
@@ -87,9 +87,11 @@ export default {
       return Math.ceil(this.listDataTotal / this.listDataMaxResults)
     },
 
-    // Constraint which prevent loadmore unexpectly
-    // if we navigating on client-side
-    // due to the list data of the first page has not been loaded.
+    /**
+     * Constraint which prevent loadmore unexpectly
+     * if we navigating on client-side
+     * due to the list data of the first page has not been loaded.
+     */
     shouldMountInfiniteLoading() {
       return this.listDataCurrentPage >= 1
     },

--- a/pages/tag/_id.vue
+++ b/pages/tag/_id.vue
@@ -96,9 +96,11 @@ export default {
       return Math.ceil(this.listDataTotal / this.listDataMaxResults)
     },
 
-    // Constraint which prevent loadmore unexpectly
-    // if we navigating on client-side
-    // due to the list data of the first page has not been loaded.
+    /**
+     * Constraint which prevent loadmore unexpectly
+     * if we navigating on client-side
+     * due to the list data of the first page has not been loaded.
+     */
     shouldMountInfiniteLoading() {
       return this.listDataCurrentPage >= 1
     },

--- a/pages/topic/_id.vue
+++ b/pages/topic/_id.vue
@@ -45,9 +45,11 @@ export default {
       return Math.ceil(this.listDataTotal / this.listDataMaxResults)
     },
 
-    // Constraint which prevent loadmore unexpectly
-    // if we navigating on client-side
-    // due to the list data of the first page has not been loaded.
+    /**
+     * Constraint which prevent loadmore unexpectly
+     * if we navigating on client-side
+     * due to the list data of the first page has not been loaded.
+     */
     shouldMountInfiniteLoading() {
       return this.listDataCurrentPage >= 1
     },

--- a/plugins/gpt-ad/__tests__/gpt-ad.spec.js
+++ b/plugins/gpt-ad/__tests__/gpt-ad.spec.js
@@ -11,10 +11,13 @@ describe('adNetwork settings', () => {
     const localVue = createLocalVue()
     localVue.use(
       plugin
-      // adNetwork is missing in plugin option
-      // {
-      //   adNetwork: '',
-      // }
+
+      /**
+       * adNetwork is missing in plugin option
+       * {
+       *   adNetwork: '',
+       * }
+       */
     )
 
     const TestWrapperComponent = {

--- a/plugins/gpt-ad/index.js
+++ b/plugins/gpt-ad/index.js
@@ -30,7 +30,7 @@ export default {
         }
 
         window.googletag.cmd.push(() => {
-          /*
+          /**
            * Do not use lazy loading with SRA.
            *
            * With lazy loading in SRA,
@@ -43,10 +43,14 @@ export default {
           window.googletag.pubads().enableLazyLoad({
             // Fetch slots within 1.5 viewports.
             fetchMarginPercent: 150,
+
             // Render slots within 1 viewports.
             renderMarginPercent: 100,
-            // Double the above values on mobile, where viewports are smaller
-            // and users tend to scroll faster.
+
+            /**
+             * Double the above values on mobile, where viewports are smaller
+             * and users tend to scroll faster.
+             */
             mobileScaling: 2.0,
           })
           window.googletag.pubads().collapseEmptyDivs()

--- a/plugins/gpt-ad/util.js
+++ b/plugins/gpt-ad/util.js
@@ -1,7 +1,7 @@
 export function getAdSizeType(adSize = []) {
-  /*
-   ** see: https://developers.google.com/doubleclick-gpt/guides/ad-sizes
-   ** Ad size should be just ONE of these cases
+  /**
+   * see: https://developers.google.com/doubleclick-gpt/guides/ad-sizes
+   * Ad size should be just ONE of these cases
    */
   const sizeValidators = [
     function fixed() {
@@ -16,6 +16,7 @@ export function getAdSizeType(adSize = []) {
       return adSize.length === 1 && adSize[0] === 'fluid' ? 'fluid' : undefined
     },
   ]
+
   // output 'fixed', 'multi, 'fluid' or undefined
   const sizeValidator = sizeValidators.find(function findTruth(validator) {
     return validator()

--- a/plugins/requests/index.js
+++ b/plugins/requests/index.js
@@ -29,8 +29,7 @@ async function fetchAPIData(url) {
     const hasData =
       (data.items && data.items.length > 0) ||
       (data.endpoints && Object.keys(data.endpoints).length > 0) ||
-      // properties responsed by /search api
-      (data.hits && data.hits.total > 0) ||
+      (data.hits && data.hits.total > 0) || // properties responsed by /search api
       (url.startsWith('/tags') && data.id)
 
     if (hasData) {

--- a/server/index.js
+++ b/server/index.js
@@ -18,6 +18,7 @@ async function start() {
   const { host, port } = nuxt.options.server
 
   await nuxt.ready()
+
   // Build only in dev mode
   if (config.dev) {
     const builder = new Builder(nuxt)

--- a/test/helpers/createWrapperHelper.js
+++ b/test/helpers/createWrapperHelper.js
@@ -1,9 +1,9 @@
 import { shallowMount } from '@vue/test-utils'
 import _ from 'lodash'
 
-/*
- ** lodash mergeWith customizer let us can override objValue with array or empty object
- ** see: https://lodash.com/docs/4.17.15#mergeWith
+/**
+ * lodash mergeWith customizer let us can override objValue with array or empty object
+ * see: https://lodash.com/docs/4.17.15#mergeWith
  */
 const customizer = function (objValue, srcValue) {
   if (Array.isArray(srcValue)) {


### PR DESCRIPTION
Comments 樣式規範參考自 [Airbnb JavaScript Style Guide](https://github.com/airbnb/javascript#comments)（可以先看對 [ESlint 設定檔](https://github.com/mirror-media/mirror-media-nuxt/pull/238/files#diff-e2954b558f2aa82baff0e30964490d12942e0e251c1aa56c3294de6ec67b7cf5)的更改），有幾點要注意：
- ESlint 無法規範多行註解要以 `/**` 開頭，無法自動 fix，這次是手動改，之後盡量統一成這個樣式，但不強制：
```javascript
/**
 * 盡量用這一個
 */

/*
 ** 這是我們之前有用過的
 */

/*
 * 假設你用 // 來表示多行註解，ESlint 會幫你改成這樣
 */
```
- ESlint 無法規範多行註解的 `*` 之後要空一格，但就盡量統一，以免影響閱讀：
```javascript
/**
 *可以這樣寫，不會報錯，但盡量不要
 */
```
- 為什麼 `multiline-comment-style` 和 `lines-around-comment` 是用 `warn` 而非 `error`？因為有些情況下，我們可能是想把多行程式碼註解掉，但並不是想把它們當成說明的註解，比如在 `pages/__tests__/search.spec.js`  有這段：
```javascript
// test('section title should be null if section query in url not exist', () => {
//   const wrapper = createWrapper(page)
//   expect(wrapper.vm.sectionQueryTitle).toBe(null)
// })
test('section title should be null if section id cannot be found in section store', () => {
  const sectionIdMock = 'test-id'
  const sectionTitleMock = 'test-title'

  // ...
})
```
我不太清楚為何不把被註解掉的這段程式碼刪掉（也許是未來某些條件滿足後，就可以改用這段程式碼？），但它顯然跟一般的註解不同（之後盡量沒用到的程式碼就刪掉）。

另外就是我們在開發網頁時，有時會想暫時註解掉某些程式碼，在 VSCode `⌘ + /`，只會幫你用 `//` 註解，這時如果用 `error`，網頁就會被警示蓋住，導致開發不順。`lines-around-comment` 也是如此。

---

有什麼其它想法都歡迎提出~