### PR TITLE
fix: use proper url for Google Cloud Storage

### DIFF
--- a/plugins/article/href.js
+++ b/plugins/article/href.js
@@ -6,15 +6,15 @@ export function getHref(articleData = {}) {
   const articlesMap = [
     {
       style: 'campaign',
-      href: `/campaigns/${slug}`,
+      href: `/campaigns/${slug}/`,
     },
     {
       style: 'projects',
-      href: `/projects/${slug}`,
+      href: `/projects/${slug}/`,
     },
     {
       style: 'readr',
-      href: `${READR_URL}/project/${slug}`,
+      href: `${READR_URL}/project/${slug}/`,
     },
   ]
 


### PR DESCRIPTION
Refs: https://cloud.google.com/storage/docs/static-website\#examples

@bcgodev says:
> 補充一下今天對於 projects 的 index.html 出現的事情，我看了 nginx 並沒有幫 project 加上 index.html 這樣的設定，301 跟 nginx 並沒有關係，而後端也會直接把 request 直接導向 GCS。
> 
> 如果仔細看周子飛 301 到 `http://www.mirrormedia.mg/projects/zhou_zhi_fei/index.html` 的回應的話，也會發現屬於 GCS 的 header。
>
> 參考 https://cloud.google.com/storage/docs/static-website#examples
可以知道是 project 的網址有誤，因為 project 的 GCS 裡是一個目錄而不是檔案，所以 GCS 會回 301 到 `index.html` ，正確的處理方式應該是鏡週刊對於 project 的網址要使用 `http://www.mirrormedia.mg/projects/zhou_zhi_fei/` 而非 `http://www.mirrormedia.mg/projects/zhou_zhi_fei`。
>
> 使用目錄的話，在 GCS 設定正確時，GCS 也會直接回覆 200 與 index.html 的內容而非 301，對於以前有 index.html 的 project 不會有問題，而且還會減少一個轉址，增加瀏覽速度。