### PR TITLE
feat(api): add /api/membership for membership proxy

### DIFF
--- a/api/__tests__/helpers.spec.js
+++ b/api/__tests__/helpers.spec.js
@@ -1,0 +1,54 @@
+jest.mock('axios')
+const axios = require('axios')
+const { createProxy } = require('../helpers')
+
+describe('createProxy helper function', function () {
+  const mockRes = {
+    setHeader: jest.fn(),
+    status: jest.fn(() => ({
+      send: jest.fn(),
+    })),
+    send: jest.fn(),
+  }
+
+  describe('behaviors about axios parameters', function () {
+    beforeEach(() => {
+      axios.mockReturnValue(
+        Promise.resolve({
+          data: {},
+        })
+      )
+    })
+
+    test('should called with dynamic base url and request url by axios', function () {
+      const mockBaseUrl = 'http://mock/api'
+      const mockReqUrl = '/mockEndpoint'
+      const proxy = createProxy(mockBaseUrl)
+      proxy({ url: mockReqUrl }, mockRes, () => {})
+      expect(axios).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: `${mockBaseUrl}${mockReqUrl}`,
+        })
+      )
+    })
+
+    test('should called with dynamic request header by axios', function () {
+      const mockReqHeaderAuthorization = 'Bearer token'
+      const proxy = createProxy()
+      proxy(
+        {
+          headers: { Authorization: mockReqHeaderAuthorization },
+        },
+        mockRes,
+        () => {}
+      )
+      expect(axios).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: {
+            Authorization: mockReqHeaderAuthorization,
+          },
+        })
+      )
+    })
+  })
+})

--- a/api/helpers.js
+++ b/api/helpers.js
@@ -1,0 +1,31 @@
+const axios = require('axios')
+const { API_TIMEOUT } = require('../configs/config')
+
+function createProxy(baseUrl) {
+  return async function (req, res, next) {
+    try {
+      const response = await axios({
+        method: req.method,
+        url: `${baseUrl}${req.url}`,
+        headers: req.headers,
+        data: req.method === 'GET' ? undefined : req.body,
+        timeout: API_TIMEOUT,
+      })
+
+      if (response.data._status === 'ERR') {
+        res.setHeader('Cache-Control', 'no-store')
+      }
+      res.send(response.data)
+    } catch (error) {
+      res.setHeader('Cache-Control', 'no-store')
+      res.status(500).send(error.message)
+
+      // eslint-disable-next-line no-console
+      console.error(`[API] url: ${req.url}`, error)
+    }
+  }
+}
+
+module.exports = {
+  createProxy,
+}

--- a/api/index.js
+++ b/api/index.js
@@ -1,30 +1,4 @@
-const axios = require('axios')
+const { API_HOST, API_PORT, API_PROTOCOL } = require('../configs/config')
+const { createProxy } = require('./helpers')
 
-const {
-  API_HOST,
-  API_PORT,
-  API_PROTOCOL,
-  API_TIMEOUT,
-} = require('../configs/config')
-
-module.exports = async function (req, res, next) {
-  try {
-    const response = await axios({
-      method: req.method,
-      url: `${API_PROTOCOL}://${API_HOST}:${API_PORT}${req.url}`,
-      data: req.method === 'GET' ? undefined : req.body,
-      timeout: API_TIMEOUT,
-    })
-
-    if (response.data._status === 'ERR') {
-      res.setHeader('Cache-Control', 'no-store')
-    }
-    res.send(response.data)
-  } catch (error) {
-    res.setHeader('Cache-Control', 'no-store')
-    res.status(500).send(error.message)
-
-    // eslint-disable-next-line no-console
-    console.error(`[API] url: ${req.url}`, error)
-  }
-}
+module.exports = createProxy(`${API_PROTOCOL}://${API_HOST}:${API_PORT}`)

--- a/api/membership-proxy.js
+++ b/api/membership-proxy.js
@@ -1,0 +1,11 @@
+const {
+  API_PROTOCOL,
+  API_HOST_MEMBERSHIP_GATEWAY,
+  API_PATH_MEMBERSHIP_GATEWAY,
+  API_PORT_MEMBERSHIP_GATEWAY,
+} = require('../configs/config')
+const { createProxy } = require('./helpers')
+
+module.exports = createProxy(
+  `${API_PROTOCOL}://${API_HOST_MEMBERSHIP_GATEWAY}:${API_PORT_MEMBERSHIP_GATEWAY}${API_PATH_MEMBERSHIP_GATEWAY}`
+)

--- a/jest.config.js
+++ b/jest.config.js
@@ -18,6 +18,7 @@ module.exports = {
     '<rootDir>/components/**/*.vue',
     '<rootDir>/pages/**/*.vue',
     '<rootDir>/plugins/**/*.js',
+    '<rootDir>/api/**/*.js',
   ],
   setupFiles: [
     '<rootDir>/plugins/vueDirectivesGlobal.js',

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -181,6 +181,7 @@ module.exports = {
       path: '/api/tracking',
       handler: '~/api/tracking.js',
     },
+    { path: '/api/membership', handler: '~/api/membership-proxy.js' },
     { path: '/api', handler: '~/api/index.js' },
   ],
 


### PR DESCRIPTION
1. 新增一個 front-end server endpoint `/api/membership`，其功用與 `/api` 相同，只不過後端位址不同與需要加送 authorization header。
2. 由於 `/api/membership` 與 `/api` 功能大致相同，將原本 `~/api/index.js` 的邏輯搬移到 `~/api/helpers.js`  的 `createProxy` 中，供 proxy 功能（單純將 request 原封不動的送至後端，且將 response 原封不動的從後端傳送至前端，沒有太多加工邏輯）的 front-end server endpoint 使用。