### PR TITLE
fix(story): embed iframes

### DIFF
--- a/components/UiStoryContentHandler.vue
+++ b/components/UiStoryContentHandler.vue
@@ -156,12 +156,10 @@ export default {
 
           case 'embeddedcode':
             return (
-              <LazyRenderer class="story__embedded-code">
-                <div
-                  class="story__embedded-code"
-                  domPropsInnerHTML={addTitleAndLazyloadToIframe(content)}
-                ></div>
-              </LazyRenderer>
+              <div
+                class="story__embedded-code"
+                domPropsInnerHTML={content.embeddedCode}
+              ></div>
             )
 
           case 'audio':
@@ -251,13 +249,6 @@ export default {
       return content.replace(
         'target="_blank"',
         'target="_blank" rel="noopener noreferrer"'
-      )
-    }
-
-    function addTitleAndLazyloadToIframe(content = {}) {
-      return content.embeddedCode.replace(
-        '<iframe',
-        `<iframe title="${content.caption}" loading="lazy"`
       )
     }
 

--- a/server/index.js
+++ b/server/index.js
@@ -20,6 +20,9 @@ async function start() {
   app.use(
     helmet({
       contentSecurityPolicy: false,
+      referrerPolicy: false,
+      noSniff: false,
+      frameguard: false,
     })
   )
 


### PR DESCRIPTION
**問題**
無法嵌入TikTok 的影片

**原因**
嵌入的時機可分為 client-side 跟 server-side

client-side 由於是使用 `v-html` 的方式插入 script，因此瀏覽器會擋住 script 的執行

server-side 會執行 script，但卻因為有用套件 helmet 做一些防護措施，導致 iframe 出不來

**解決方法**
讓 embedded code 在 server-side 執行，並移除會影響 iframe 顯示的安全措施

對 iframe 加上 `loading="lazy"` 似乎也會影響，故也移除