### PR TITLE
feat: show covered video if heroVideo has data

### DIFF
--- a/components/culture-post/ContainerCulturePost.vue
+++ b/components/culture-post/ContainerCulturePost.vue
@@ -13,7 +13,12 @@
       @openIndex="handleIndexActive(true)"
     />
 
-    <UiTheCover :title="post.title" :picture="post.coverPicture" />
+    <UiTheCover
+      :title="post.title"
+      :picture="post.coverPicture"
+      :src="heroVideoSrc"
+      :poster="heroVideoPoster"
+    />
 
     <div class="info">
       <div>發布時間 {{ post.publishedDate }}</div>
@@ -107,9 +112,7 @@ export default {
         updatedAt = '',
         relateds = [],
       } = this.story
-
       const heroImgsResized = heroImage.image?.resizedTargets || {}
-
       return {
         title,
         credits: getCredits(),
@@ -172,6 +175,17 @@ export default {
           id: item.id,
           content: item.content[0],
         }))
+    },
+    heroVideo() {
+      return this.story.heroVideo || {}
+    },
+    heroVideoSrc() {
+      return this.heroVideo.video?.url || false
+    },
+    heroVideoPoster() {
+      return (
+        this.heroVideo.coverPhoto?.image?.resizedTargets?.mobile?.url || false
+      )
     },
     updatedAt() {
       return this.post.updatedAt

--- a/components/culture-post/ContainerCulturePost.vue
+++ b/components/culture-post/ContainerCulturePost.vue
@@ -15,9 +15,8 @@
 
     <UiTheCover
       :title="post.title"
+      :video="post.coverVideo"
       :picture="post.coverPicture"
-      :src="heroVideoSrc"
-      :poster="heroVideoPoster"
     />
 
     <div class="info">
@@ -106,19 +105,29 @@ export default {
         cameraMan = [],
         extendByline = '',
         content = {},
+        heroVideo = {},
         heroImage = {},
         mobileImage = {},
         publishedDate = '',
         updatedAt = '',
         relateds = [],
       } = this.story
+
+      const heroVideoSrc = heroVideo.video?.url || false
+      const heroVideoPoster =
+        heroVideo.coverPhoto?.image?.resizedTargets?.mobile?.url || false
       const heroImgsResized = heroImage.image?.resizedTargets || {}
+
       return {
         title,
         credits: getCredits(),
         brief: getBrief(),
         content: content.apiData || [],
         heroImage: heroImgsResized,
+        coverVideo: {
+          heroVideoSrc,
+          heroVideoPoster,
+        },
         coverPicture: {
           heroImage: heroImgsResized,
           mobileImage: mobileImage.image?.resizedTargets || {},
@@ -175,17 +184,6 @@ export default {
           id: item.id,
           content: item.content[0],
         }))
-    },
-    heroVideo() {
-      return this.story.heroVideo || {}
-    },
-    heroVideoSrc() {
-      return this.heroVideo.video?.url || false
-    },
-    heroVideoPoster() {
-      return (
-        this.heroVideo.coverPhoto?.image?.resizedTargets?.mobile?.url || false
-      )
     },
     updatedAt() {
       return this.post.updatedAt

--- a/components/culture-post/ContainerCulturePost.vue
+++ b/components/culture-post/ContainerCulturePost.vue
@@ -113,8 +113,8 @@ export default {
         relateds = [],
       } = this.story
 
-      const heroVideoSrc = heroVideo.video?.url || false
-      const heroVideoPoster =
+      const src = heroVideo.video?.url || false
+      const poster =
         heroVideo.coverPhoto?.image?.resizedTargets?.mobile?.url || false
       const heroImgsResized = heroImage.image?.resizedTargets || {}
 
@@ -125,8 +125,8 @@ export default {
         content: content.apiData || [],
         heroImage: heroImgsResized,
         coverVideo: {
-          heroVideoSrc,
-          heroVideoPoster,
+          src,
+          poster,
         },
         coverPicture: {
           heroImage: heroImgsResized,

--- a/components/culture-post/ContainerCulturePost.vue
+++ b/components/culture-post/ContainerCulturePost.vue
@@ -113,8 +113,8 @@ export default {
         relateds = [],
       } = this.story
 
-      const src = heroVideo.video?.url || false
-      const poster =
+      const heroVideoSrc = heroVideo.video?.url || ''
+      const heroVideoPoster =
         heroVideo.coverPhoto?.image?.resizedTargets?.mobile?.url || false
       const heroImgsResized = heroImage.image?.resizedTargets || {}
 
@@ -125,8 +125,8 @@ export default {
         content: content.apiData || [],
         heroImage: heroImgsResized,
         coverVideo: {
-          src,
-          poster,
+          src: heroVideoSrc,
+          poster: heroVideoPoster,
         },
         coverPicture: {
           heroImage: heroImgsResized,

--- a/components/culture-post/UiTheCover.vue
+++ b/components/culture-post/UiTheCover.vue
@@ -3,15 +3,7 @@
     <!-- eslint-disable-next-line vue/no-v-html -->
     <h1 v-html="title"></h1>
 
-    <video
-      v-if="src"
-      :src="src"
-      :poster="poster"
-      preload="metadata"
-      controlsList="nodownload"
-      controls
-      playsinline
-    />
+    <UiStoryVideo v-if="src" :src="src" :poster="poster" class="video" />
 
     <picture v-else>
       <source :srcset="imgSrcLandscape" media="(min-width: 992px)" />
@@ -30,9 +22,13 @@
 
 <script>
 import { mapState } from 'vuex'
+import UiStoryVideo from '~/components/UiStoryVideo.vue'
 
 export default {
   name: 'UiTheCover',
+  components: {
+    UiStoryVideo,
+  },
 
   props: {
     title: {
@@ -108,6 +104,11 @@ h1 {
   }
 }
 
+.video {
+  position: absolute;
+  height: 100%;
+}
+
 picture {
   position: relative;
   display: block;
@@ -124,14 +125,6 @@ picture {
     bottom: 0;
     background: linear-gradient(0deg, rgba(0, 0, 0, 0.15), rgba(0, 0, 0, 0.15));
   }
-}
-
-video {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  outline: none;
-  object-fit: cover;
 }
 
 img {

--- a/components/culture-post/UiTheCover.vue
+++ b/components/culture-post/UiTheCover.vue
@@ -4,9 +4,9 @@
     <h1 v-html="title"></h1>
 
     <video
-      v-if="videoSrc"
-      :src="videoSrc"
-      :poster="videoPoster"
+      v-if="src"
+      :src="src"
+      :poster="poster"
       preload="metadata"
       controlsList="nodownload"
       controls
@@ -63,11 +63,11 @@ export default {
       return `${this.viewportHeight}px`
     },
 
-    videoSrc() {
-      return this.video.heroVideoSrc
+    src() {
+      return this.video.src
     },
-    videoPoster() {
-      return this.video.heroVideoPoster
+    poster() {
+      return this.video.poster
     },
     imgSrcLandscape() {
       return this.picture.heroImage.desktop?.url

--- a/components/culture-post/UiTheCover.vue
+++ b/components/culture-post/UiTheCover.vue
@@ -4,9 +4,9 @@
     <h1 v-html="title"></h1>
 
     <video
-      v-if="src"
-      :src="src"
-      :poster="poster"
+      v-if="videoSrc"
+      :src="videoSrc"
+      :poster="videoPoster"
       preload="metadata"
       controlsList="nodownload"
       controls
@@ -40,18 +40,14 @@ export default {
       default: '',
       required: true,
     },
+    video: {
+      type: Object,
+      default: () => ({}),
+    },
     picture: {
       type: Object,
       default: () => ({}),
       required: true,
-    },
-    src: {
-      type: String,
-      required: true,
-    },
-    poster: {
-      type: [String, Boolean],
-      default: false,
     },
   },
 
@@ -67,6 +63,12 @@ export default {
       return `${this.viewportHeight}px`
     },
 
+    videoSrc() {
+      return this.video.heroVideoSrc
+    },
+    videoPoster() {
+      return this.video.heroVideoPoster
+    },
     imgSrcLandscape() {
       return this.picture.heroImage.desktop?.url
     },

--- a/components/culture-post/UiTheCover.vue
+++ b/components/culture-post/UiTheCover.vue
@@ -3,7 +3,12 @@
     <!-- eslint-disable-next-line vue/no-v-html -->
     <h1 v-html="title"></h1>
 
-    <UiStoryVideo v-if="src" :src="src" :poster="poster" class="video" />
+    <UiStoryVideo
+      v-if="videoSrc"
+      :src="videoSrc"
+      :poster="videoPoster"
+      class="video"
+    />
 
     <picture v-else>
       <source :srcset="imgSrcLandscape" media="(min-width: 992px)" />
@@ -59,10 +64,10 @@ export default {
       return `${this.viewportHeight}px`
     },
 
-    src() {
+    videoSrc() {
       return this.video.src
     },
-    poster() {
+    videoPoster() {
       return this.video.poster
     },
     imgSrcLandscape() {

--- a/components/culture-post/UiTheCover.vue
+++ b/components/culture-post/UiTheCover.vue
@@ -3,7 +3,17 @@
     <!-- eslint-disable-next-line vue/no-v-html -->
     <h1 v-html="title"></h1>
 
-    <picture>
+    <video
+      v-if="src"
+      :src="src"
+      :poster="poster"
+      preload="metadata"
+      controlsList="nodownload"
+      controls
+      playsinline
+    />
+
+    <picture v-else>
       <source :srcset="imgSrcLandscape" media="(min-width: 992px)" />
       <source
         :srcset="imgSrcLandscape"
@@ -34,6 +44,14 @@ export default {
       type: Object,
       default: () => ({}),
       required: true,
+    },
+    src: {
+      type: String,
+      required: true,
+    },
+    poster: {
+      type: [String, Boolean],
+      default: false,
     },
   },
 
@@ -104,6 +122,14 @@ picture {
     bottom: 0;
     background: linear-gradient(0deg, rgba(0, 0, 0, 0.15), rgba(0, 0, 0, 0.15));
   }
+}
+
+video {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  outline: none;
+  object-fit: cover;
 }
 
 img {


### PR DESCRIPTION
1. 在 premium 情況下(目前以style=wide表示)，story頁若存在影片( heroVideo )，則影片為滿版。
2. 影片寬高與形式已在 local 和 Tin 確認過，在行動裝置中會持續縮窄，在桌機中上下會被部分切除，文字維持壓在影片上。
3. 這張卡片沒有設計稿，版型同目前測試機的滿版圖片：https://nuxt-dev.mirrormedia.mg/story/test_video
4. 後台資料：http://35.189.183.129:3000/keystone/posts/5ab47c34340ca60e00e549dd
5. 卡片連結：https://app.asana.com/0/1199948555976980/1199966228155154/f