### PR TITLE
feat: add a new meta tag named dable-image to pass tiny images

### DIFF
--- a/components/culture-post/ContainerCulturePost.vue
+++ b/components/culture-post/ContainerCulturePost.vue
@@ -278,6 +278,7 @@ export default {
     const { title = '', brief = '', heroImage = {} } = this.post
     const description = brief.map((item) => item.content).join('')
     const image = heroImage.desktop?.url || SITE_OG_IMG
+    const dableImgUrl = heroImage.tiny?.url || SITE_OG_IMG
 
     return {
       title,
@@ -299,6 +300,7 @@ export default {
           content: `${SITE_URL}${this.$route.path}`,
         },
         { hid: 'og:image', property: 'og:image', content: image },
+        { property: 'dable:image', content: dableImgUrl },
         { hid: 'twitter:title', name: 'twitter:title', content: title },
         {
           hid: 'twitter:description',

--- a/pages/external/_slug.vue
+++ b/pages/external/_slug.vue
@@ -456,6 +456,7 @@ export default {
         { hid: 'twitter:image', name: 'twitter:image', content: thumb },
         { property: 'dable:item_id', content: this.storySlug },
         { property: 'dable:author', content: partnerDisplay },
+        { property: 'dable:image', content: thumb },
         { property: 'article:section', content: '合作媒體' },
         { property: 'article:section2', content: partnerDisplay },
         { property: 'article:published_time', content: publishedDateIso },

--- a/pages/premium/_slug.vue
+++ b/pages/premium/_slug.vue
@@ -121,6 +121,10 @@ export default {
       ogImage?.image?.resizedTargets?.tablet?.url ||
       heroImage?.image?.resizedTargets?.tablet?.url ||
       SITE_OG_IMG
+    const dableImgUrl =
+      ogImage?.image?.resizedTargets?.tiny?.url ||
+      heroImage?.image?.resizedTargets?.tiny?.url ||
+      SITE_OG_IMG
     const pageUrl = `https://${DOMAIN_NAME}${this.$route.path}`
 
     const publishedDateIso = new Date(publishedDate).toISOString()
@@ -167,6 +171,7 @@ export default {
         { hid: 'twitter:image', name: 'twitter:image', content: imgUrl },
         { property: 'dable:item_id', content: this.storySlug },
         { property: 'dable:author', content: writerName },
+        { property: 'dable:image', content: dableImgUrl },
         this.hasSection
           ? {
               property: 'article:section',

--- a/pages/story/_slug.vue
+++ b/pages/story/_slug.vue
@@ -694,6 +694,10 @@ export default {
       ogImage?.image?.resizedTargets?.tablet?.url ||
       heroImage?.image?.resizedTargets?.tablet?.url ||
       SITE_OG_IMG
+    const dableImgUrl =
+      ogImage?.image?.resizedTargets?.tiny?.url ||
+      heroImage?.image?.resizedTargets?.tiny?.url ||
+      SITE_OG_IMG
     const pageUrl = `https://${DOMAIN_NAME}${this.$route.path}`
 
     const publishedDateIso = new Date(publishedDate).toISOString()
@@ -740,6 +744,7 @@ export default {
         { hid: 'twitter:image', name: 'twitter:image', content: imgUrl },
         { property: 'dable:item_id', content: this.storySlug },
         { property: 'dable:author', content: writerName },
+        { property: 'dable:image', content: dableImgUrl },
         this.hasSection
           ? {
               property: 'article:section',

--- a/pages/video/_id.vue
+++ b/pages/video/_id.vue
@@ -167,6 +167,10 @@ export default {
       this.videoData?.thumbnails?.maxres?.url ||
       this.videoData?.thumbnails?.standard?.url ||
       SITE_OG_IMG
+    const dableImgUrl =
+      this.videoData?.thumbnails?.medium?.url ||
+      this.videoData?.thumbnails?.standard?.url ||
+      SITE_OG_IMG
     return {
       title: this.title,
       meta: [
@@ -187,6 +191,7 @@ export default {
           content: `${SITE_URL}${this.$route.path}`,
         },
         { hid: 'og:image', property: 'og:image', content: image },
+        { property: 'dable:image', content: dableImgUrl },
         { hid: 'twitter:title', name: 'twitter:title', content: this.title },
         {
           hid: 'twitter:description',


### PR DESCRIPTION
1. 在與文章相關的頁面、元件之head meta 增加 dable:image ，以提供編輯部dable後台較小的照片縮圖。
2. external頁、premium頁不確定需求，此份PR仍有增加此 meta tag。
3. video 相關縮圖，考量畫質問題，目前改採medium或standard。

需求文件：https://app.asana.com/0/1200021598612109/1200066366547236