### PR TITLE
fix: display share area when index list is empty

### DIFF
--- a/components/culture-post/UiArticleIndex.vue
+++ b/components/culture-post/UiArticleIndex.vue
@@ -35,9 +35,7 @@
             </ul>
           </div>
 
-          <div
-            :class="['share', { 'share--hide-on-desktop': items.length <= 0 }]"
-          >
+          <div :class="['share', { 'share--with-no-list': items.length <= 0 }]">
             <p>分享到：</p>
             <UiShareFb />
             <UiShareLine />
@@ -292,10 +290,8 @@ export default {
     }
   }
 
-  &--hide-on-desktop {
-    @include media-breakpoint-up(xl) {
-      display: none;
-    }
+  &--with-no-list {
+    z-index: -1;
   }
 }
 

--- a/components/culture-post/UiArticleIndex.vue
+++ b/components/culture-post/UiArticleIndex.vue
@@ -291,6 +291,7 @@ export default {
   }
 
   &--with-no-list {
+    position: relative;
     z-index: -1;
   }
 }


### PR DESCRIPTION
在索引無內容時，仍會呈現fb與line分享按鈕

需求文件 (Asana)：https://app.asana.com/0/1200072715055847/1200052271701246