### PR TITLE
feat: add magazine button to wide page

### DIFF
--- a/components/culture-post/ContainerCulturePost.vue
+++ b/components/culture-post/ContainerCulturePost.vue
@@ -280,10 +280,7 @@ export default {
       this.relatedImgs = items
     },
     enterMagazinePage() {
-      const pagePath = '/magazine/'
-      window.location.href = this.isLoggedIn
-        ? pagePath
-        : `/login/?destination=${pagePath}`
+      window.location.href = '/magazine/'
     },
   },
 

--- a/components/culture-post/ContainerCulturePost.vue
+++ b/components/culture-post/ContainerCulturePost.vue
@@ -44,13 +44,6 @@
       :content="post.content"
     />
 
-    <div class="culture-post__article-body">
-      <div class="magazine">
-        <div>下載鏡週刊電子雜誌</div>
-        <button type="button" @click="enterMagazinePage">立即下載</button>
-      </div>
-    </div>
-
     <LazyRenderer
       v-if="doesHaveAnyRelateds"
       class="list-related-container"
@@ -279,9 +272,6 @@ export default {
 
       this.relatedImgs = items
     },
-    enterMagazinePage() {
-      window.location.href = '/magazine/'
-    },
   },
 
   head() {
@@ -385,43 +375,6 @@ export default {
     margin-left: 12px;
     @include media-breakpoint-up(lg) {
       margin-left: 24px;
-    }
-  }
-}
-
-.magazine {
-  margin: 24px 27px;
-  font-size: 24px;
-  line-height: 36px;
-  text-align: center;
-  background-color: #fff;
-  padding: 20px;
-  color: #054f77;
-  border: 1px solid rgba(155, 155, 155, 0.2);
-  box-shadow: 0px 0px 20px -4px rgba(0, 0, 0, 0.2);
-  border-radius: 4px;
-  @include media-breakpoint-up(xl) {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 24px 32px;
-    font-size: 20px;
-  }
-
-  button {
-    width: 100%;
-    background-color: #1d9fb8;
-    border-radius: 2px;
-    line-height: 1.38;
-    color: #fff;
-    padding: 12px 4px;
-    margin-top: 16px;
-    font-size: 18px;
-    line-height: 25px;
-    @include media-breakpoint-up(xl) {
-      margin-top: 0;
-      max-width: 170px;
-      line-height: 27px;
     }
   }
 }

--- a/components/culture-post/ContainerCulturePost.vue
+++ b/components/culture-post/ContainerCulturePost.vue
@@ -44,6 +44,13 @@
       :content="post.content"
     />
 
+    <div class="culture-post__article-body">
+      <div class="magazine">
+        <div>下載鏡週刊電子雜誌</div>
+        <button type="button" @click="enterMagazinePage">立即下載</button>
+      </div>
+    </div>
+
     <LazyRenderer
       v-if="doesHaveAnyRelateds"
       class="list-related-container"
@@ -272,6 +279,12 @@ export default {
 
       this.relatedImgs = items
     },
+    enterMagazinePage() {
+      const pagePath = '/magazine/'
+      window.location.href = this.isLoggedIn
+        ? pagePath
+        : `/login/?destination=${pagePath}`
+    },
   },
 
   head() {
@@ -375,6 +388,43 @@ export default {
     margin-left: 12px;
     @include media-breakpoint-up(lg) {
       margin-left: 24px;
+    }
+  }
+}
+
+.magazine {
+  margin: 24px 27px;
+  font-size: 24px;
+  line-height: 36px;
+  text-align: center;
+  background-color: #fff;
+  padding: 20px;
+  color: #054f77;
+  border: 1px solid rgba(155, 155, 155, 0.2);
+  box-shadow: 0px 0px 20px -4px rgba(0, 0, 0, 0.2);
+  border-radius: 4px;
+  @include media-breakpoint-up(xl) {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 24px 32px;
+    font-size: 20px;
+  }
+
+  button {
+    width: 100%;
+    background-color: #1d9fb8;
+    border-radius: 2px;
+    line-height: 1.38;
+    color: #fff;
+    padding: 12px 4px;
+    margin-top: 16px;
+    font-size: 18px;
+    line-height: 25px;
+    @include media-breakpoint-up(xl) {
+      margin-top: 0;
+      max-width: 170px;
+      line-height: 27px;
     }
   }
 }

--- a/components/culture-post/UiArticleBody.vue
+++ b/components/culture-post/UiArticleBody.vue
@@ -6,6 +6,11 @@
     </div>
 
     <ContentHandler v-for="item in content" :key="item.id" :item="item" />
+
+    <div class="magazine">
+      <div>下載鏡週刊電子雜誌</div>
+      <button type="button" @click="enterMagazinePage">立即下載</button>
+    </div>
   </article>
 </template>
 
@@ -35,6 +40,11 @@ export default {
   computed: {
     doesHaveBrief() {
       return this.brief.length > 0
+    },
+  },
+  methods: {
+    enterMagazinePage() {
+      window.location.href = '/magazine/'
     },
   },
 }
@@ -98,6 +108,43 @@ export default {
 
     p + p {
       margin-top: 2em;
+    }
+  }
+}
+
+.magazine {
+  margin: 24px 27px;
+  font-size: 24px;
+  line-height: 36px;
+  text-align: center;
+  background-color: #fff;
+  padding: 20px;
+  color: #054f77;
+  border: 1px solid rgba(155, 155, 155, 0.2);
+  box-shadow: 0px 0px 20px -4px rgba(0, 0, 0, 0.2);
+  border-radius: 4px;
+  @include media-breakpoint-up(xl) {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 24px 32px;
+    font-size: 20px;
+  }
+
+  button {
+    width: 100%;
+    background-color: #1d9fb8;
+    border-radius: 2px;
+    line-height: 1.38;
+    color: #fff;
+    padding: 12px 4px;
+    margin-top: 16px;
+    font-size: 18px;
+    line-height: 25px;
+    @include media-breakpoint-up(xl) {
+      margin-top: 0;
+      max-width: 170px;
+      line-height: 27px;
     }
   }
 }


### PR DESCRIPTION
1. 在 wide 版面增加 magazine 按鈕，並判斷是否為會員，導入不同頁面。
2. 由於按鈕的css和非會員其他版面的按鈕有些差異，因此並未提取為獨立的元件。

需求：https://app.asana.com/0/1200072715055847/1200078750709895 (已修正為wide版型也需要製作，形式與會員一致)
設計：https://www.figma.com/file/qmocxMBHG6D7T2VPdydRWG/%E9%8F%A1%E7%B6%B2%E7%AB%99(%E6%9C%83%E5%93%A1)?node-id=1143%3A0