### PR TITLE
feat: add magazine-page entry to member section

### DIFF
--- a/components/UiHeaderNavSection.vue
+++ b/components/UiHeaderNavSection.vue
@@ -81,6 +81,9 @@ export default {
       if (sectionName === 'videohub') {
         return `/video_category/${categoryName}`
       }
+      if (categoryName === 'magazine') {
+        return '/magazine/'
+      }
       return `/category/${categoryName}`
     },
     emitGa(eventLabel) {

--- a/components/UiSidebar.vue
+++ b/components/UiSidebar.vue
@@ -169,6 +169,9 @@ export default {
       if (sectionName === 'videohub') {
         return `/video_category/${categoryName}`
       }
+      if (categoryName === 'magazine') {
+        return '/magazine/'
+      }
       return `/category/${categoryName}`
     },
     emitGa(eventLabel) {

--- a/store/index.js
+++ b/store/index.js
@@ -32,4 +32,5 @@ export const actions = {
 
 function commitSectionsData(commit, response) {
   commit('sections/setSectionsData', response.endpoints.sections ?? {})
+  commit('sections/addMagazineToMemberSection')
 }

--- a/store/sections.js
+++ b/store/sections.js
@@ -51,6 +51,25 @@ export const mutations = {
   setSectionsData(state, data) {
     state.data = data
   },
+  addMagazineToMemberSection(state) {
+    state.data.items?.forEach((section) => {
+      if (section.name === 'member') {
+        section.categories?.unshift({
+          id: '5a02e0e31a53670d7778b990',
+          isCampaign: false,
+          isFeatured: false,
+          isMemberOnly: true,
+          name: 'magazine',
+          style: 'feature',
+          title: '電子雜誌',
+          css: '',
+          javascript: '',
+          ogDescription: '',
+          ogTitle: '',
+        })
+      }
+    })
+  },
 }
 
 export const actions = {


### PR DESCRIPTION
1. 在header中的member區塊內，加入「電子雜誌」子區塊，連結到magazine頁。
2. 討論後，決定不改動原section、cms欄位，而是直接寫死加入。
3. 新加入的「電子雜誌」要在member區塊的最上方

需求文件：https://app.asana.com/0/1200072715055847/1200041811234963