### PR TITLE
fix: redirect to /projects/ especially for zhou_zhi_fei

### DIFF
--- a/components/UiArticleList.vue
+++ b/components/UiArticleList.vue
@@ -12,7 +12,7 @@
       <template v-for="(item, index) in listItems">
         <li :key="item.id" class="list__list-item">
           <UiArticleCard
-            :href="item.href"
+            :href="isSlugZhouZhiFei(item.href)"
             :imgSrc="item.imgSrc"
             :imgText="item.imgText"
             :imgTextBackgroundColor="item.imgTextBackgroundColor"
@@ -83,6 +83,12 @@ export default {
     },
     getMicroAdSlotNameAfter(index) {
       return this.indexToMicroAdName[index]
+    },
+    isSlugZhouZhiFei(href) {
+      if (href === '/story/zhou_zhi_fei') {
+        return 'projects/zhou_zhi_fei'
+      }
+      return href
     },
     isSlotForMicroAd(unit) {
       return Object.keys(this.$slots).includes(unit)


### PR DESCRIPTION
1. 將「周子飛」專題，由「 /story/ 」改為 「 /projects/ 」
2. 此次僅針對「周子飛」專題進行修改，若要完整解決 projects 文章導向問題，還需和編輯部確認專題文章的使用方式


專題連結：https://www.mirrormedia.mg/projects/zhou_zhi_fei/