### PR TITLE
feat: redesign props of subscribe success order info

### DIFF
--- a/components/PurchasedList.vue
+++ b/components/PurchasedList.vue
@@ -1,0 +1,70 @@
+<template>
+  <div class="content_row__data_wrapper">
+    <div
+      v-for="rowItem in data"
+      :key="rowItem.text"
+      class="content_row__data_wrapper_row"
+    >
+      <div>{{ rowItem.text }}</div>
+      <div>NT$ {{ rowItem.price }}</div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    data: {
+      type: Array,
+      default: () => [
+        {
+          text: 'test row item',
+          price: 123,
+        },
+        {
+          text: 'test row item',
+          price: 123,
+        },
+      ],
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.content_row__data {
+  display: block;
+  flex: 1;
+  @include media-breakpoint-up(sm) {
+    display: flex;
+  }
+
+  &_wrapper {
+    margin-top: 12px;
+    flex: 1;
+    @include media-breakpoint-up(sm) {
+      margin-top: 0px;
+    }
+
+    &_row {
+      display: flex;
+      justify-content: space-between;
+
+      & + & {
+        margin-top: 8px;
+        @include media-breakpoint-up(sm) {
+          margin-top: 14px;
+        }
+      }
+
+      &:last-child {
+        padding-top: 10px;
+        border-top: solid 1px #4a4a4a;
+        @include media-breakpoint-up(sm) {
+          padding-top: 18px;
+        }
+      }
+    }
+  }
+}
+</style>

--- a/components/SubscribeSimFormStatus.vue
+++ b/components/SubscribeSimFormStatus.vue
@@ -60,6 +60,11 @@ export default {
       this.simOrderStatus = e.target.value
     },
     clickHandler(e) {
+      if (this.simOrderStatus === 'success') {
+        this.$store.dispatch('subscribe/updateOrderInfo', {
+          pur_name: 'test name',
+        })
+      }
       this.$store.dispatch('subscribe/updateResultStatus', this.simOrderStatus)
 
       this.$router.push('/subscribe/result')

--- a/components/SubscribeSuccess.vue
+++ b/components/SubscribeSuccess.vue
@@ -6,6 +6,7 @@
       <SubscribeSuccessOrderInfo
         :orderInfo="orderInfo"
         :customerInfo="customerInfo"
+        :filteredPerchasedPlan="filteredPerchasedPlan"
         :shipCost="shipCost"
       />
 
@@ -45,6 +46,18 @@ export default {
     },
   },
   computed: {
+    filteredPerchasedPlan() {
+      const itemList = [
+        {
+          id: 0,
+          name: this.orderInfo.item_desc,
+          price: this.orderInfo.price,
+          amount: this.orderInfo.amount,
+        },
+      ]
+
+      return itemList
+    },
     shipCost() {
       if (this.orderInfo.delivery === '限時專送') return 0
       return 20

--- a/components/SubscribeSuccess.vue
+++ b/components/SubscribeSuccess.vue
@@ -5,9 +5,8 @@
 
       <SubscribeSuccessOrderInfo
         :orderInfo="orderInfo"
+        :orderInfoPurchasedList="orderInfoPurchasedList"
         :customerInfo="customerInfo"
-        :filteredPerchasedPlan="filteredPerchasedPlan"
-        :shipCost="shipCost"
       />
 
       <UiSubscribeInfo />
@@ -31,6 +30,10 @@ export default {
         return {}
       },
     },
+    orderInfoPurchasedList: {
+      type: Array,
+      default: () => [],
+    },
     customerInfo: {
       type: Object,
       default: () => {
@@ -43,24 +46,6 @@ export default {
           rec_addr: '',
         }
       },
-    },
-  },
-  computed: {
-    filteredPerchasedPlan() {
-      const itemList = [
-        {
-          id: 0,
-          name: this.orderInfo.item_desc,
-          price: this.orderInfo.price,
-          amount: this.orderInfo.amount,
-        },
-      ]
-
-      return itemList
-    },
-    shipCost() {
-      if (this.orderInfo.delivery === '限時專送') return 0
-      return 20
     },
   },
 }

--- a/components/SubscribeSuccess.vue
+++ b/components/SubscribeSuccess.vue
@@ -3,7 +3,11 @@
     <div class="order-success__wrapper">
       <p>您已完成付款，以下為本次訂購資訊，已同步寄送至您的信箱。</p>
 
-      <SubscribeSuccessOrderInfo :orderInfo="orderInfo" :orderId="orderId" />
+      <SubscribeSuccessOrderInfo
+        :orderInfo="orderInfo"
+        :orderId="orderId"
+        :customerInfo="customerInfo"
+      />
 
       <UiSubscribeInfo />
     </div>
@@ -30,6 +34,19 @@ export default {
       type: String,
       isRequired: true,
       default: 'orderId',
+    },
+    customerInfo: {
+      type: Object,
+      default: () => {
+        return {
+          pur_name: '',
+          pur_mail: '',
+          pur_cell: '',
+          rec_name: '',
+          rec_cell: '',
+          rec_addr: '',
+        }
+      },
     },
   },
 }

--- a/components/SubscribeSuccess.vue
+++ b/components/SubscribeSuccess.vue
@@ -5,7 +5,6 @@
 
       <SubscribeSuccessOrderInfo
         :orderInfo="orderInfo"
-        :orderId="orderId"
         :customerInfo="customerInfo"
       />
 
@@ -29,11 +28,6 @@ export default {
       default: () => {
         return {}
       },
-    },
-    orderId: {
-      type: String,
-      isRequired: true,
-      default: 'orderId',
     },
     customerInfo: {
       type: Object,

--- a/components/SubscribeSuccess.vue
+++ b/components/SubscribeSuccess.vue
@@ -6,6 +6,7 @@
       <SubscribeSuccessOrderInfo
         :orderInfo="orderInfo"
         :customerInfo="customerInfo"
+        :shipCost="shipCost"
       />
 
       <UiSubscribeInfo />
@@ -41,6 +42,12 @@ export default {
           rec_addr: '',
         }
       },
+    },
+  },
+  computed: {
+    shipCost() {
+      if (this.orderInfo.delivery === '限時專送') return 0
+      return 20
     },
   },
 }

--- a/components/SubscribeSuccessOrderInfo.vue
+++ b/components/SubscribeSuccessOrderInfo.vue
@@ -16,9 +16,8 @@
           title="訂單日期"
           :data="orderDate"
         />
-        <SubscribeSuccessOrderInfoContentRow
+        <SubscribeSuccessOrderInfoContentRowPurchasedList
           title="訂單內容"
-          data=""
           :totalCost="orderInfo.price_total"
           :perchasedList="fileterPerchasedPlan"
           :shipCost="shipCost"
@@ -75,10 +74,12 @@
 <script>
 import dayjs from 'dayjs'
 import SubscribeSuccessOrderInfoContentRow from '~/components/SubscribeSuccessOrderInfoContentRow.vue'
+import SubscribeSuccessOrderInfoContentRowPurchasedList from '~/components/SubscribeSuccessOrderInfoContentRowPurchasedList.vue'
 
 export default {
   components: {
     SubscribeSuccessOrderInfoContentRow,
+    SubscribeSuccessOrderInfoContentRowPurchasedList,
   },
   props: {
     orderInfo: {

--- a/components/SubscribeSuccessOrderInfo.vue
+++ b/components/SubscribeSuccessOrderInfo.vue
@@ -69,7 +69,7 @@
 </template>
 
 <script>
-import moment from 'moment'
+import dayjs from 'dayjs'
 import SubscribeSuccessOrderInfoContentRow from '~/components/SubscribeSuccessOrderInfoContentRow.vue'
 
 export default {
@@ -106,7 +106,7 @@ export default {
   computed: {
     orderDate() {
       const now = new Date()
-      return moment(now).format('YYYY-MM-DD')
+      return dayjs(now).format('YYYY-MM-DD')
     },
     fileterPerchasedPlan() {
       const itemList = [

--- a/components/SubscribeSuccessOrderInfo.vue
+++ b/components/SubscribeSuccessOrderInfo.vue
@@ -18,9 +18,7 @@
         />
         <SubscribeSuccessOrderInfoContentRowPurchasedList
           title="訂單內容"
-          :totalCost="orderInfo.price_total"
-          :perchasedList="filteredPerchasedPlan"
-          :shipCost="shipCost"
+          :perchasedList="orderInfoPurchasedList"
           class="order-info__order_content_perchased"
         />
       </div>
@@ -88,6 +86,10 @@ export default {
       default: () => {
         return {}
       },
+    },
+    orderInfoPurchasedList: {
+      type: Array,
+      default: () => [],
     },
     customerInfo: {
       type: Object,

--- a/components/SubscribeSuccessOrderInfo.vue
+++ b/components/SubscribeSuccessOrderInfo.vue
@@ -102,6 +102,10 @@ export default {
         }
       },
     },
+    shipCost: {
+      type: Number,
+      default: 0,
+    },
   },
   computed: {
     orderDate() {
@@ -119,10 +123,6 @@ export default {
       ]
 
       return itemList
-    },
-    shipCost() {
-      if (this.orderInfo.delivery === '限時專送') return 0
-      return 20
     },
     shouldShowCustomerInfo() {
       const isAnyValueInCustomInfoTruthy = Object.values(

--- a/components/SubscribeSuccessOrderInfo.vue
+++ b/components/SubscribeSuccessOrderInfo.vue
@@ -83,6 +83,19 @@ export default {
       isRequired: true,
       default: 'orderId',
     },
+    customerInfo: {
+      type: Object,
+      default: () => {
+        return {
+          pur_name: '',
+          pur_email: '',
+          pur_cell: '',
+          rec_name: '',
+          rec_cell: '',
+          rec_addr: '',
+        }
+      },
+    },
   },
   computed: {
     orderDate() {

--- a/components/SubscribeSuccessOrderInfo.vue
+++ b/components/SubscribeSuccessOrderInfo.vue
@@ -27,31 +27,37 @@
       <div class="order-info__user_content">
         <div class="order-info__user_content_title">訂購人</div>
         <SubscribeSuccessOrderInfoContentRow
+          class="pur_name"
           title="姓名"
-          :data="orderInfo.pur_name"
+          :data="customerInfo.pur_name"
         />
         <SubscribeSuccessOrderInfoContentRow
+          class="pur_mail"
           title="電子信箱"
-          :data="orderInfo.pur_mail"
+          :data="customerInfo.pur_mail"
         />
         <SubscribeSuccessOrderInfoContentRow
+          class="pur_cell"
           title="聯絡電話"
-          :data="orderInfo.pur_cell"
+          :data="customerInfo.pur_cell"
         />
       </div>
       <div class="order-info__user_content">
         <div class="order-info__user_content_title">收件人</div>
         <SubscribeSuccessOrderInfoContentRow
+          class="rec_name"
           title="姓名"
-          :data="orderInfo.rec_name"
+          :data="customerInfo.rec_name"
         />
         <SubscribeSuccessOrderInfoContentRow
+          class="rec_cell"
           title="聯絡電話"
-          :data="orderInfo.rec_cell"
+          :data="customerInfo.rec_cell"
         />
         <SubscribeSuccessOrderInfoContentRow
+          class="rec_addr"
           title="通訊地址"
-          :data="orderInfo.rec_addr"
+          :data="customerInfo.rec_addr"
         />
         <!-- <SubscribeSuccessOrderInfoContentRow
           title="派送備註"
@@ -88,7 +94,7 @@ export default {
       default: () => {
         return {
           pur_name: '',
-          pur_email: '',
+          pur_mail: '',
           pur_cell: '',
           rec_name: '',
           rec_cell: '',

--- a/components/SubscribeSuccessOrderInfo.vue
+++ b/components/SubscribeSuccessOrderInfo.vue
@@ -3,7 +3,11 @@
     <div class="order-info__order">
       <div class="order-info__order_title">訂單資訊</div>
       <div class="order-info__order_content">
-        <SubscribeSuccessOrderInfoContentRow title="訂單編號" :data="orderId" />
+        <SubscribeSuccessOrderInfoContentRow
+          class="order-id"
+          title="訂單編號"
+          :data="orderInfo.orderId"
+        />
         <!-- <SubscribeSuccessOrderInfoContentRow
           title="續訂戶代碼"
           data="窩不知道"
@@ -83,11 +87,6 @@ export default {
       default: () => {
         return {}
       },
-    },
-    orderId: {
-      type: String,
-      isRequired: true,
-      default: 'orderId',
     },
     customerInfo: {
       type: Object,

--- a/components/SubscribeSuccessOrderInfo.vue
+++ b/components/SubscribeSuccessOrderInfo.vue
@@ -22,7 +22,7 @@
         />
       </div>
     </div>
-    <div class="order-info__user">
+    <div v-if="shouldShowCustomerInfo" class="order-info__user">
       <div class="order-info__user_title">顧客資訊</div>
       <div class="order-info__user_content">
         <div class="order-info__user_content_title">訂購人</div>
@@ -123,6 +123,14 @@ export default {
     shipCost() {
       if (this.orderInfo.delivery === '限時專送') return 0
       return 20
+    },
+    shouldShowCustomerInfo() {
+      const isAnyValueInCustomInfoTruthy = Object.values(
+        this.customerInfo
+      ).reduce(function reduceWithAnyTruthy(acc, curr) {
+        return acc || curr
+      }, false)
+      return isAnyValueInCustomInfoTruthy
     },
   },
 }

--- a/components/SubscribeSuccessOrderInfo.vue
+++ b/components/SubscribeSuccessOrderInfo.vue
@@ -19,7 +19,7 @@
         <SubscribeSuccessOrderInfoContentRowPurchasedList
           title="訂單內容"
           :totalCost="orderInfo.price_total"
-          :perchasedList="fileterPerchasedPlan"
+          :perchasedList="filteredPerchasedPlan"
           :shipCost="shipCost"
           class="order-info__order_content_perchased"
         />
@@ -102,6 +102,10 @@ export default {
         }
       },
     },
+    filteredPerchasedPlan: {
+      type: Array,
+      default: () => [],
+    },
     shipCost: {
       type: Number,
       default: 0,
@@ -111,18 +115,6 @@ export default {
     orderDate() {
       const now = new Date()
       return dayjs(now).format('YYYY-MM-DD')
-    },
-    fileterPerchasedPlan() {
-      const itemList = [
-        {
-          id: 0,
-          name: this.orderInfo.item_desc,
-          price: this.orderInfo.price,
-          amount: this.orderInfo.amount,
-        },
-      ]
-
-      return itemList
     },
     shouldShowCustomerInfo() {
       const isAnyValueInCustomInfoTruthy = Object.values(

--- a/components/SubscribeSuccessOrderInfoContentRow.vue
+++ b/components/SubscribeSuccessOrderInfoContentRow.vue
@@ -3,26 +3,6 @@
     <div class="content_row__title">{{ title }}</div>
     <div class="content_row__data">
       {{ data }}
-      <div v-if="perchasedList" class="content_row__data_wrapper">
-        <div
-          v-for="item of perchasedList"
-          :key="item.id"
-          class="content_row__data_wrapper_row"
-        >
-          <div>{{ item.name }} X {{ item.amount }}</div>
-          <div>NT$ {{ item.price * item.amount }}</div>
-        </div>
-        <div
-          class="content_row__data_wrapper_row content_row__data_wrapper_ship"
-        >
-          <div>運費</div>
-          <div>NT$ {{ shipCost }}</div>
-        </div>
-        <div class="content_row__data_wrapper_row">
-          <div>總計</div>
-          <div>NT$ {{ totalCost }}</div>
-        </div>
-      </div>
     </div>
   </div>
 </template>
@@ -36,18 +16,6 @@ export default {
     },
     data: {
       type: String,
-      isRequired: false,
-    },
-    shipCost: {
-      type: Number,
-      isRequired: false,
-    },
-    perchasedList: {
-      type: Array,
-      isRequired: false,
-    },
-    totalCost: {
-      type: Number,
       isRequired: false,
     },
   },
@@ -80,34 +48,6 @@ export default {
   flex: 1;
   @include media-breakpoint-up(sm) {
     display: flex;
-  }
-
-  &_wrapper {
-    margin-top: 12px;
-    flex: 1;
-    @include media-breakpoint-up(sm) {
-      margin-top: 0px;
-    }
-
-    &_row {
-      display: flex;
-      justify-content: space-between;
-
-      & + & {
-        margin-top: 8px;
-        @include media-breakpoint-up(sm) {
-          margin-top: 14px;
-        }
-      }
-    }
-
-    &_ship {
-      padding-bottom: 10px;
-      border-bottom: solid 1px #4a4a4a;
-      @include media-breakpoint-up(sm) {
-        padding-bottom: 18px;
-      }
-    }
   }
 }
 </style>

--- a/components/SubscribeSuccessOrderInfoContentRowPurchasedList.vue
+++ b/components/SubscribeSuccessOrderInfoContentRowPurchasedList.vue
@@ -2,48 +2,24 @@
   <div class="content_row">
     <div class="content_row__title">{{ title }}</div>
     <div class="content_row__data">
-      <div class="content_row__data_wrapper">
-        <div
-          v-for="item of perchasedList"
-          :key="item.id"
-          class="content_row__data_wrapper_row"
-        >
-          <div>{{ item.name }} X {{ item.amount }}</div>
-          <div>NT$ {{ item.price * item.amount }}</div>
-        </div>
-        <div
-          class="content_row__data_wrapper_row content_row__data_wrapper_ship"
-        >
-          <div>運費</div>
-          <div>NT$ {{ shipCost }}</div>
-        </div>
-        <div class="content_row__data_wrapper_row">
-          <div>總計</div>
-          <div>NT$ {{ totalCost }}</div>
-        </div>
-      </div>
+      <PurchasedList :data="perchasedList" />
     </div>
   </div>
 </template>
 
 <script>
+import PurchasedList from '~/components/PurchasedList.vue'
+
 export default {
+  components: { PurchasedList },
   props: {
     title: {
       type: String,
       isRequired: true,
     },
-    shipCost: {
-      type: Number,
-      isRequired: false,
-    },
     perchasedList: {
       type: Array,
-      isRequired: false,
-    },
-    totalCost: {
-      type: Number,
-      isRequired: false,
+      required: true,
     },
   },
   computed: {},
@@ -75,34 +51,6 @@ export default {
   flex: 1;
   @include media-breakpoint-up(sm) {
     display: flex;
-  }
-
-  &_wrapper {
-    margin-top: 12px;
-    flex: 1;
-    @include media-breakpoint-up(sm) {
-      margin-top: 0px;
-    }
-
-    &_row {
-      display: flex;
-      justify-content: space-between;
-
-      & + & {
-        margin-top: 8px;
-        @include media-breakpoint-up(sm) {
-          margin-top: 14px;
-        }
-      }
-    }
-
-    &_ship {
-      padding-bottom: 10px;
-      border-bottom: solid 1px #4a4a4a;
-      @include media-breakpoint-up(sm) {
-        padding-bottom: 18px;
-      }
-    }
   }
 }
 </style>

--- a/components/SubscribeSuccessOrderInfoContentRowPurchasedList.vue
+++ b/components/SubscribeSuccessOrderInfoContentRowPurchasedList.vue
@@ -1,0 +1,108 @@
+<template>
+  <div class="content_row">
+    <div class="content_row__title">{{ title }}</div>
+    <div class="content_row__data">
+      <div class="content_row__data_wrapper">
+        <div
+          v-for="item of perchasedList"
+          :key="item.id"
+          class="content_row__data_wrapper_row"
+        >
+          <div>{{ item.name }} X {{ item.amount }}</div>
+          <div>NT$ {{ item.price * item.amount }}</div>
+        </div>
+        <div
+          class="content_row__data_wrapper_row content_row__data_wrapper_ship"
+        >
+          <div>運費</div>
+          <div>NT$ {{ shipCost }}</div>
+        </div>
+        <div class="content_row__data_wrapper_row">
+          <div>總計</div>
+          <div>NT$ {{ totalCost }}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    title: {
+      type: String,
+      isRequired: true,
+    },
+    shipCost: {
+      type: Number,
+      isRequired: false,
+    },
+    perchasedList: {
+      type: Array,
+      isRequired: false,
+    },
+    totalCost: {
+      type: Number,
+      isRequired: false,
+    },
+  },
+  computed: {},
+}
+</script>
+
+<style lang="scss" scoped>
+.content_row {
+  display: flex;
+  & + & {
+    margin-top: 12px;
+
+    @include media-breakpoint-up(sm) {
+      margin-top: 18px;
+    }
+  }
+}
+
+.content_row__title {
+  min-width: 97px;
+
+  @include media-breakpoint-up(sm) {
+    min-width: 150px;
+  }
+}
+
+.content_row__data {
+  display: block;
+  flex: 1;
+  @include media-breakpoint-up(sm) {
+    display: flex;
+  }
+
+  &_wrapper {
+    margin-top: 12px;
+    flex: 1;
+    @include media-breakpoint-up(sm) {
+      margin-top: 0px;
+    }
+
+    &_row {
+      display: flex;
+      justify-content: space-between;
+
+      & + & {
+        margin-top: 8px;
+        @include media-breakpoint-up(sm) {
+          margin-top: 14px;
+        }
+      }
+    }
+
+    &_ship {
+      padding-bottom: 10px;
+      border-bottom: solid 1px #4a4a4a;
+      @include media-breakpoint-up(sm) {
+        padding-bottom: 18px;
+      }
+    }
+  }
+}
+</style>

--- a/components/__tests__/SubscribeSuccessOrderInfo.spec.js
+++ b/components/__tests__/SubscribeSuccessOrderInfo.spec.js
@@ -15,7 +15,7 @@ describe('customInfo props', function () {
     })
     expect(wrapper.find('.order-info__user').exists()).toBe(false)
   })
-  test('should show custom info if all the values in customInfo are not falsy', function () {
+  test('should show custom info if one of the values in customInfo is not falsy', function () {
     const wrapper = shallowMount(SubscribeSuccessOrderInfo, {
       propsData: {
         customerInfo: {

--- a/components/__tests__/SubscribeSuccessOrderInfo.spec.js
+++ b/components/__tests__/SubscribeSuccessOrderInfo.spec.js
@@ -1,0 +1,33 @@
+import { shallowMount } from '@vue/test-utils'
+import SubscribeSuccessOrderInfo from '~/components/SubscribeSuccessOrderInfo.vue'
+
+describe('customInfo props', function () {
+  test('should hide custom info if all the values in customInfo are falsy', function () {
+    const wrapper = shallowMount(SubscribeSuccessOrderInfo, {
+      propsData: {
+        customerInfo: {
+          every: '',
+          value: '',
+          are: '',
+          falsy: '',
+        },
+      },
+    })
+    expect(wrapper.find('.order-info__user').exists()).toBe(false)
+  })
+  test('should show custom info if all the values in customInfo are not falsy', function () {
+    const wrapper = shallowMount(SubscribeSuccessOrderInfo, {
+      propsData: {
+        customerInfo: {
+          every: '',
+          value: '',
+          are: '',
+          falsy: '',
+          expect: '',
+          thisOne: 'mock value',
+        },
+      },
+    })
+    expect(wrapper.find('.order-info__user').exists()).toBe(true)
+  })
+})

--- a/pages/__tests__/subscribe-result.spec.js
+++ b/pages/__tests__/subscribe-result.spec.js
@@ -46,3 +46,33 @@ describe('customerInfo extract from orderInfo in subscribe store state', functio
     expect(wrapper.find('.rec_addr').props().data).toBe(mockOrderInfo.rec_addr)
   })
 })
+
+describe('orderId extract from infoPayload in subscribe store state', function () {
+  let storeOptions
+  const mockInfoPayload = {
+    MerchantOrderNo: 'mockMerchantOrderNo',
+  }
+  beforeEach(() => {
+    storeOptions = {
+      modules: {
+        subscribe: {
+          namespaced: true,
+          state: stateSubscribe(),
+          getters: getterSubscribe,
+        },
+      },
+    }
+    storeOptions.modules.subscribe.state.infoPayload = mockInfoPayload
+    storeOptions.modules.subscribe.state.resultStatus = 'success'
+  })
+
+  test('should display orderId extract from infoPayload in subscribe store state correctly', function () {
+    const wrapper = mount(page, {
+      localVue,
+      store: new Vuex.Store(storeOptions),
+    })
+    expect(wrapper.find('.order-id').props().data).toBe(
+      mockInfoPayload.MerchantOrderNo
+    )
+  })
+})

--- a/pages/__tests__/subscribe-result.spec.js
+++ b/pages/__tests__/subscribe-result.spec.js
@@ -1,0 +1,48 @@
+import { createLocalVue, mount } from '@vue/test-utils'
+import Vuex from 'vuex'
+import page from '~/pages/subscribe/result'
+import {
+  getters as getterSubscribe,
+  state as stateSubscribe,
+} from '~/store/subscribe'
+
+const localVue = createLocalVue()
+localVue.use(Vuex)
+
+describe('customerInfo extract from orderInfo in subscribe store state', function () {
+  let storeOptions
+  const mockOrderInfo = {
+    pur_name: 'mockPurName',
+    pur_mail: 'mockPurEmail',
+    pur_cell: 'mockPurCell',
+    rec_name: 'mockRecName',
+    rec_cell: 'mockRecCell',
+    rec_addr: 'mockRecAddr',
+  }
+  beforeEach(() => {
+    storeOptions = {
+      modules: {
+        subscribe: {
+          namespaced: true,
+          state: stateSubscribe(),
+          getters: getterSubscribe,
+        },
+      },
+    }
+    storeOptions.modules.subscribe.state.orderInfo = mockOrderInfo
+    storeOptions.modules.subscribe.state.resultStatus = 'success'
+  })
+
+  test('should display customerInfo extract from orderInfo in subscribe store state correctly', function () {
+    const wrapper = mount(page, {
+      localVue,
+      store: new Vuex.Store(storeOptions),
+    })
+    expect(wrapper.find('.pur_name').props().data).toBe(mockOrderInfo.pur_name)
+    expect(wrapper.find('.pur_mail').props().data).toBe(mockOrderInfo.pur_mail)
+    expect(wrapper.find('.pur_cell').props().data).toBe(mockOrderInfo.pur_cell)
+    expect(wrapper.find('.rec_name').props().data).toBe(mockOrderInfo.rec_name)
+    expect(wrapper.find('.rec_cell').props().data).toBe(mockOrderInfo.rec_cell)
+    expect(wrapper.find('.rec_addr').props().data).toBe(mockOrderInfo.rec_addr)
+  })
+})

--- a/pages/subscribe/result/index.vue
+++ b/pages/subscribe/result/index.vue
@@ -9,7 +9,11 @@
 
     <template v-if="resultStatus === 'success'">
       <SubscribeStepProgress :currentStep="3" />
-      <SubscribeSuccess :orderInfo="orderInfo" :customerInfo="customerInfo" />
+      <SubscribeSuccess
+        :orderInfo="orderInfo"
+        :orderInfoPurchasedList="orderInfoPurchasedList"
+        :customerInfo="customerInfo"
+      />
     </template>
   </div>
 </template>
@@ -53,6 +57,22 @@ export default {
         ...orderInfo,
         orderId: MerchantOrderNo,
       }
+    },
+    orderInfoPurchasedList() {
+      return [
+        {
+          text: `${this.orderInfo.item_desc} X ${this.orderInfo.amount}`,
+          price: this.orderInfo.price,
+        },
+        {
+          text: '運費',
+          price: this.orderInfo.delivery === '限時掛號' ? 20 : 0,
+        },
+        {
+          text: '總計',
+          price: this.orderInfo.price_total,
+        },
+      ]
     },
     customerInfo() {
       /* eslint-disable camelcase */

--- a/pages/subscribe/result/index.vue
+++ b/pages/subscribe/result/index.vue
@@ -9,11 +9,7 @@
 
     <template v-if="resultStatus === 'success'">
       <SubscribeStepProgress :currentStep="3" />
-      <SubscribeSuccess
-        :orderInfo="orderInfo"
-        :orderId="orderId"
-        :customerInfo="customerInfo"
-      />
+      <SubscribeSuccess :orderInfo="orderInfo" :customerInfo="customerInfo" />
     </template>
   </div>
 </template>
@@ -49,7 +45,14 @@ export default {
     },
     orderInfo() {
       const orderInfo = this.$store.getters['subscribe/getOrderInfo']
-      return orderInfo
+      const { MerchantOrderNo } = this.$store.getters[
+        'subscribe/getInfoPayload'
+      ]
+
+      return {
+        ...orderInfo,
+        orderId: MerchantOrderNo,
+      }
     },
     customerInfo() {
       /* eslint-disable camelcase */

--- a/pages/subscribe/result/index.vue
+++ b/pages/subscribe/result/index.vue
@@ -9,7 +9,11 @@
 
     <template v-if="resultStatus === 'success'">
       <SubscribeStepProgress :currentStep="3" />
-      <SubscribeSuccess :orderInfo="orderInfo" :orderId="orderId" />
+      <SubscribeSuccess
+        :orderInfo="orderInfo"
+        :orderId="orderId"
+        :customerInfo="customerInfo"
+      />
     </template>
   </div>
 </template>
@@ -46,6 +50,25 @@ export default {
     orderInfo() {
       const orderInfo = this.$store.getters['subscribe/getOrderInfo']
       return orderInfo
+    },
+    customerInfo() {
+      /* eslint-disable camelcase */
+      const {
+        pur_name = '',
+        pur_mail = '',
+        pur_cell = '',
+        rec_name = '',
+        rec_cell = '',
+        rec_addr = '',
+      } = this.$store.getters['subscribe/getOrderInfo']
+      return {
+        pur_name,
+        pur_mail,
+        pur_cell,
+        rec_name,
+        rec_cell,
+        rec_addr,
+      }
     },
     orderId() {
       const { MerchantOrderNo } = this.$store.getters[


### PR DESCRIPTION
重構`SubscribeSuccessOrderInfo.vue` components：
1. （DONE）新增 `customerInfo` props，為從原本的 `orderInfo` 拆分得出，若 `customerInfo` 中所有欄位皆為空值則能做到不顯示顧客資訊區塊，為[新需求](https://www.figma.com/file/qmocxMBHG6D7T2VPdydRWG/%E9%8F%A1%E9%80%B1%E5%88%8A-%E7%B6%B2%E7%AB%99?node-id=2866%3A867)要符合的功能。
2. （DONE）修改 `orderInfo` props，使得訂單內容能夠容許進一步的客製化，達到[新需求](https://www.figma.com/file/qmocxMBHG6D7T2VPdydRWG/%E9%8F%A1%E9%80%B1%E5%88%8A-%E7%B6%B2%E7%AB%99?node-id=2866%3A867)，預計將會整併訂單編號以及運費等設定到單一 `orderInfo` props 中。
    - 已整併的 props：
      - 移除 `orderId`，整併至 `orderInfo.orderId`，如此 `SubscribeSuccess` component props 從 `orderInfo`, `orderId`, `customerInfo` 減免為 `orderInfo`, `customInfo`，剛好代表 [UI 上下兩個大分區](https://app.zeplin.io/project/5ac2f13c0f240ab10d2c7dfc/screen/5d6dd8c8fcbfc79bf449fda4)，我認為是比較直覺的介面。

重構 `SubscribeSuccessOrderInfoContentRow` components，目標：
   1. （DONE）目前這個 component 擁有兩種功能：顯示純文字、顯示價格計算公式，初步會將這兩個功能分離成兩個 components。
   2. （DONE）顯示價格計算公式的 template 目前綁定雜誌訂閱的計算方式，其實可以更廣泛地提供一個單純顯示「一串文字」+「價錢」的共用 component，以利其他[需求](https://www.figma.com/file/qmocxMBHG6D7T2VPdydRWG/%E9%8F%A1%E9%80%B1%E5%88%8A-%E7%B6%B2%E7%AB%99?node-id=2866%3A867)使用。
   3. （DONE）[Lift state up](https://reactjs.org/docs/lifting-state-up.html)，將隱含 `SubscribeSuccessOrderInfo` 中的 state（如訂單內容價格計算、運費、總計等等）提升至 page component，並修改資料結構，以利其他 page 注入不同的資料結構做到客製化[需求](https://www.figma.com/file/qmocxMBHG6D7T2VPdydRWG/%E9%8F%A1%E9%80%B1%E5%88%8A-%E7%B6%B2%E7%AB%99?node-id=2866%3A867)。