### PR TITLE
feat: adjust the redirecting-strategy of articles which type is project

### DIFF
--- a/components/UiArticleList.vue
+++ b/components/UiArticleList.vue
@@ -12,7 +12,7 @@
       <template v-for="(item, index) in listItems">
         <li :key="item.id" class="list__list-item">
           <UiArticleCard
-            :href="isSlugZhouZhiFei(item.href)"
+            :href="item.href"
             :imgSrc="item.imgSrc"
             :imgText="item.imgText"
             :imgTextBackgroundColor="item.imgTextBackgroundColor"
@@ -83,12 +83,6 @@ export default {
     },
     getMicroAdSlotNameAfter(index) {
       return this.indexToMicroAdName[index]
-    },
-    isSlugZhouZhiFei(href) {
-      if (href === '/story/zhou_zhi_fei') {
-        return '/projects/zhou_zhi_fei'
-      }
-      return href
     },
     isSlotForMicroAd(unit) {
       return Object.keys(this.$slots).includes(unit)

--- a/utils/article.js
+++ b/utils/article.js
@@ -55,10 +55,16 @@ function checkCategoryHasMemberOnly({ categories = [] } = {}) {
   })
 }
 
+function getStoryPathByType(story) {
+  return story.type === 'project'
+    ? `/projects/${story.slug}`
+    : `/story/${story.slug}`
+}
+
 function getStoryPath(story = {}) {
   return checkCategoryHasMemberOnly(story)
     ? `/premium/${story.slug}`
-    : `/story/${story.slug}`
+    : getStoryPathByType(story)
 }
 
 export {


### PR DESCRIPTION
1. 將 type 為 project 的文章，都導向 projects/${slug}。
2. 將原先單獨判斷是否為周子飛文章的函式移除。

- 需求：[Asana](https://app.asana.com/0/1200514764581162/1200520483300762)
- 非本次的修改範圍，但額外遇到的錯誤紀錄。可能是因為在 template 上使用 plugins 注入的函式：
> [Vue warn]: Property or method "$GOExp" is not defined on the instance but referenced during render. Make sure that this property is reactive, either in the data option, or for class-based components, by initializing the property. See: https://vuejs.org/v2/guide/reactivity.html#Declaring-Reactive-Properties.
