### PR TITLE
feat: show receiver data when it is same as orderer data

### DIFF
--- a/components/SubscribeForm.vue
+++ b/components/SubscribeForm.vue
@@ -9,6 +9,7 @@
         <SubscribeFormOrdererData
           ref="ordererDOM"
           type="訂購人"
+          :ordererData="ordererData"
           :setOrdererData="setOrdererData"
           :validateOn="validateOn"
           :setFormStatus="setFormStatus"
@@ -16,6 +17,7 @@
         <SubscribeFormOrdererData
           ref="receiverDOM"
           type="收件人"
+          :ordererData="ordererData"
           :setOrdererData="setOrdererData"
           :receiverDataIsSameAsOrderer="receiverDataIsSameAsOrderer"
           :setReceiverDataIsSameAsOrderer="setReceiverDataIsSameAsOrderer"

--- a/components/SubscribeForm.vue
+++ b/components/SubscribeForm.vue
@@ -418,6 +418,9 @@ export default {
     &:disabled {
       background: #e3e3e3;
       border: 1px solid rgba(0, 0, 0, 0.2);
+      color: rgba(0, 0, 0, 0.2);
+      font-size: 18px;
+      line-height: 25px;
     }
 
     &::placeholder {

--- a/components/SubscribeFormOrdererData.vue
+++ b/components/SubscribeFormOrdererData.vue
@@ -110,6 +110,10 @@ export default {
       isRequired: true,
       default: '訂購人',
     },
+    ordererData: {
+      type: Object,
+      default: () => {},
+    },
     setOrdererData: {
       type: Function,
       default: () => {},
@@ -186,12 +190,21 @@ export default {
     setDisable(e) {
       e.preventDefault()
       this.setReceiverDataIsSameAsOrderer(!this.receiverDataIsSameAsOrderer)
-      this.name = ''
-      this.cellphone = ''
-      this.phone = ''
-      this.phoneExt = ''
-      this.address = ''
-      this.email = ''
+      if (this.receiverDataIsSameAsOrderer) return
+      const {
+        name,
+        cellphone,
+        phone,
+        phoneExt,
+        address,
+        email,
+      } = this.ordererData
+      this.name = name
+      this.cellphone = cellphone
+      this.phone = phone
+      this.phoneExt = phoneExt
+      this.address = address
+      this.email = email
     },
     check() {
       if (this.isNeedToCheck) {
@@ -215,6 +228,59 @@ export default {
         phoneExt: this.phoneExt,
         address: this.address,
         email: this.email,
+      }
+    },
+  },
+  watch: {
+    ordererData: {
+      deep: true,
+      handler() {
+        if (this.receiverDataIsSameAsOrderer) {
+          const {
+            name,
+            cellphone,
+            phone,
+            phoneExt,
+            address,
+            email,
+          } = this.ordererData
+          this.name = name
+          this.cellphone = cellphone
+          this.phone = phone
+          this.phoneExt = phoneExt
+          this.address = address
+          this.email = email
+        }
+      },
+    },
+    name(val) {
+      if (this.getFormType === 'orderer') {
+        this.setOrdererData({ ...this.ordererData, name: val })
+      }
+    },
+    cellphone(val) {
+      if (this.getFormType === 'orderer') {
+        this.setOrdererData({ ...this.ordererData, cellphone: val })
+      }
+    },
+    phone(val) {
+      if (this.getFormType === 'orderer') {
+        this.setOrdererData({ ...this.ordererData, phone: val })
+      }
+    },
+    phoneExt(val) {
+      if (this.getFormType === 'orderer') {
+        this.setOrdererData({ ...this.ordererData, phoneExt: val })
+      }
+    },
+    address(val) {
+      if (this.getFormType === 'orderer') {
+        this.setOrdererData({ ...this.ordererData, address: val })
+      }
+    },
+    email(val) {
+      if (this.getFormType === 'orderer') {
+        this.setOrdererData({ ...this.ordererData, email: val })
       }
     },
   },


### PR DESCRIPTION
- 當勾選「同訂購人資訊」時，欄位自動填上相同資訊。
- 更改錯誤訊息和 disable 時的狀態。

 ### 思路：
1. 將 `SubscribeForm` 中的 `ordererData` 和 `setOrdererData` 作為 props 傳入。
2. watch `SubscribeForm` 中各個 input 值，當有變化時若 `type = '訂購人'` ，則用 `setOrdererData` 及時更改 `ordererData`。如此一來便可確保 `ordererData` 永遠保持在最新狀態。
3. 按下「同訂購人資訊」時，若偵測到是打勾（**這裏不知為何 `this.receiverDataIsSameAsOrderer` 必須是 false 而非 true，要麻煩 reviewer 解答了，感謝**），`setDisable()` 可將 component 中的 data 和 `ordererData` 同步。
4. 到上一部為止，我們打勾時可以看到兩者資料同步了，再來為了讓使用者在打勾後就算更改訂購人資料也能及時更新，一但 watch 到 `ordererData` 有更動，也要再同步一次資料。

### 參考資料：
- [卡片](https://app.asana.com/0/1200570778319695/1200581556792681)
- [文件](https://paper.dropbox.com/doc/--BOkkQe3P28cU7XeaNldlzRdbAg-jgnC27r3xclTCRRfCdqUi)
- [設計稿](https://www.figma.com/file/qmocxMBHG6D7T2VPdydRWG/%E9%8F%A1%E9%80%B1%E5%88%8A---%E7%B6%B2%E7%AB%99?node-id=3202%3A14412)