### PR TITLE
feat: adjust ship method area

### DIFF
--- a/components/SubscribeForm.vue
+++ b/components/SubscribeForm.vue
@@ -125,7 +125,7 @@ export default {
         email: '',
       },
       shipPlan: {
-        name: '限時專送',
+        name: '一般配送',
         cost: 0,
       },
       receiptData: {

--- a/components/SubscribeFormShip.vue
+++ b/components/SubscribeFormShip.vue
@@ -15,7 +15,11 @@
       <UiSubscribeRadioInput
         v-model="shipPlanName"
         radioValue="限時掛號"
-        radioName="限時掛號 NT$ 20 / 期"
+        :radioName="`限時掛號 NT$ ${registeredCost} / 期`"
+        :hints="[
+          `一年期加收 NT$ ${numberWithComma(registeredCost * 52)}`,
+          `二年期加收 NT$ ${numberWithComma(registeredCost * 52 * 2)}`,
+        ]"
       />
     </div>
   </div>
@@ -38,7 +42,13 @@ export default {
   data() {
     return {
       shipPlanName: '一般配送',
+      registeredCost: 20,
     }
+  },
+  methods: {
+    numberWithComma(number) {
+      return number.toLocaleString()
+    },
   },
   watch: {
     shipPlanName(val) {
@@ -53,7 +63,7 @@ export default {
         case '限時掛號':
           this.setShipPlan({
             name: '限時掛號',
-            cost: 20,
+            cost: this.registeredCost,
           })
           break
 

--- a/components/SubscribeFormShip.vue
+++ b/components/SubscribeFormShip.vue
@@ -10,7 +10,7 @@
       <UiSubscribeRadioInput
         v-model="shipPlanName"
         radioValue="一般配送"
-        radioName="限時專送 NT$ 0 / 期"
+        radioName="一般配送 NT$ 0 / 期"
       />
       <UiSubscribeRadioInput
         v-model="shipPlanName"
@@ -37,15 +37,15 @@ export default {
   },
   data() {
     return {
-      shipPlanName: '限時專送',
+      shipPlanName: '一般配送',
     }
   },
   watch: {
     shipPlanName(val) {
       switch (val) {
-        case '限時專送':
+        case '一般配送':
           this.setShipPlan({
-            name: '限時專送',
+            name: '一般配送',
             cost: 0,
           })
           break
@@ -59,7 +59,7 @@ export default {
 
         default:
           this.setShipPlan({
-            name: '限時專送',
+            name: '一般配送',
             cost: 0,
           })
           break

--- a/components/UiSubscribeRadioInput.vue
+++ b/components/UiSubscribeRadioInput.vue
@@ -1,12 +1,18 @@
 <template>
   <div class="radio-input">
-    <input
-      :checked="value === radioValue"
-      type="radio"
-      :value="radioValue"
-      @input="changeHandler"
-    />
-    <span class="radio">{{ radioName }}</span>
+    <div class="radio-input__input">
+      <input
+        :checked="value === radioValue"
+        type="radio"
+        :value="radioValue"
+        @input="changeHandler"
+      />
+      <span class="radio">{{ radioName }} </span>
+    </div>
+    <ul v-if="radioValue === '限時掛號'" class="radio-input__total">
+      <li>一年期加收 NT$ 1,040</li>
+      <li>二年期加收 NT$ 2,080</li>
+    </ul>
   </div>
 </template>
 
@@ -40,14 +46,23 @@ export default {
 
 <style lang="scss" scoped>
 .radio-input {
-  display: flex;
-  align-items: center;
   margin-bottom: 10px;
-  font-size: 18px;
-  line-height: normal;
+  &__input {
+    display: flex;
+    align-items: center;
+    font-size: 18px;
+    line-height: normal;
 
-  input[type='radio'] {
-    margin-right: 8px;
+    input[type='radio'] {
+      margin-right: 8px;
+    }
+  }
+
+  &__total {
+    margin-left: 50px;
+    font-size: 16px;
+    list-style: disc;
+    line-height: 1.5;
   }
 }
 </style>

--- a/components/UiSubscribeRadioInput.vue
+++ b/components/UiSubscribeRadioInput.vue
@@ -10,8 +10,9 @@
       <span class="radio">{{ radioName }} </span>
     </div>
     <ul v-if="radioValue === '限時掛號'" class="radio-input__total">
-      <li>一年期加收 NT$ 1,040</li>
-      <li>二年期加收 NT$ 2,080</li>
+      <li v-for="hint in hints" :key="hint.text">
+        {{ hint }}
+      </li>
     </ul>
   </div>
 </template>
@@ -23,6 +24,10 @@ export default {
       type: String,
       isRequired: true,
       default: '',
+    },
+    hints: {
+      type: Array,
+      default: () => [],
     },
     radioValue: {
       type: String,


### PR DESCRIPTION
- 預設選項為：一般配送
- 在掛號配送下方增加兩欄總金額說明

### 問題
- 總金額如果不寫死的話好像較易維護，不過不確定資料該怎麼存？

### 參考資料：
- [卡片](https://app.asana.com/0/1200570778319695/1200581556792679)
- [文件](https://paper.dropbox.com/doc/--BOkkQe3P28cU7XeaNldlzRdbAg-jgnC27r3xclTCRRfCdqUi)
- [設計稿](https://www.figma.com/file/qmocxMBHG6D7T2VPdydRWG/%E9%8F%A1%E9%80%B1%E5%88%8A---%E7%B6%B2%E7%AB%99?node-id=3202%3A14412)