### PR TITLE
feat: pop-up counted by button instead of input

### DIFF
--- a/components/SubscribeFormEditPerchase.vue
+++ b/components/SubscribeFormEditPerchase.vue
@@ -10,8 +10,8 @@
           :perchasedPlan="waitToEdittedPerchasedPlan"
           :showAll="true"
           :class="{ error: bothCountZero || tooManyPlans }"
+          :isPopUp="true"
         />
-
         <div class="edit-perchase__dialog_controller">
           <UiSubscribeButton
             :title="`取消`"

--- a/components/SubscribeFormEditPerchase.vue
+++ b/components/SubscribeFormEditPerchase.vue
@@ -11,6 +11,7 @@
           :showAll="true"
           :class="{ error: bothCountZero || tooManyPlans }"
           :isPopUp="true"
+          :setCount="setCount"
         />
         <div class="edit-perchase__dialog_controller">
           <UiSubscribeButton
@@ -121,6 +122,17 @@ export default {
   methods: {
     toggleHandler() {
       this.isToggled = !this.isToggled
+    },
+    setCount(direction, id) {
+      this.waitToEdittedPerchasedPlan.map((plan) => {
+        if (plan.id === id) {
+          if (direction === 'decrease') {
+            if (this.isDisable(plan.id)) return
+            return plan.count--
+          }
+          plan.count++
+        }
+      })
     },
     cancelModification() {
       this.isToggled = !this.isToggled

--- a/components/SubscribeFormPlanList.vue
+++ b/components/SubscribeFormPlanList.vue
@@ -5,7 +5,7 @@
       <SubscribeFormEditPerchase :perchasedPlan="perchasedPlan" />
     </div>
 
-    <UiMerchandiseList :perchasedPlan="perchasedPlan" />
+    <UiMerchandiseList :perchasedPlan="perchasedPlan" :isPopUp="false" />
 
     <!-- <div class="merchandise-list__discount_code">
       <div class="merchandise-list__discount_code_row">

--- a/components/UiMerchandiseList.vue
+++ b/components/UiMerchandiseList.vue
@@ -9,15 +9,27 @@
     <div class="merchandise-list-detail__form_devider" />
 
     <div
-      v-for="perchased in filteredPerchasedPlan"
+      v-for="perchased in tempPerchasedPlan"
       :key="perchased.id"
       class="merchandise-list-detail__form_content form-row"
     >
       <div class="form-row__head_title" :class="{ pop_up: isPopUp }">
         {{ perchased.detail }}
       </div>
-      <div class="form-row__head_title">
+      <div class="form-row__head_title form-row__head_title_count">
+        <UiSubscribeCountButton
+          v-show="isPopUp"
+          type="decrease"
+          :isDisable="isDisable(perchased.id)"
+          @click.native="setCount('decrease', perchased.id)"
+        />
         {{ perchased.count }}
+        <UiSubscribeCountButton
+          v-show="isPopUp"
+          type="increase"
+          :isDisable="false"
+          @click.native="setCount('increase', perchased.id)"
+        />
       </div>
       <div class="form-row__head_title">NT${{ perchased.newPrice }}</div>
     </div>
@@ -25,7 +37,11 @@
 </template>
 
 <script>
+import UiSubscribeCountButton from '~/components/UiSubscribeCountButton.vue'
 export default {
+  components: {
+    UiSubscribeCountButton,
+  },
   props: {
     perchasedPlan: {
       type: Array,
@@ -61,7 +77,12 @@ export default {
     },
   },
   data() {
-    return {}
+    return {
+      tempPerchasedPlan: [],
+    }
+  },
+  created() {
+    this.tempPerchasedPlan = this.filteredPerchasedPlan
   },
   computed: {
     filteredPerchasedPlan() {
@@ -72,6 +93,31 @@ export default {
       else {
         return this.perchasedPlan
       }
+    },
+  },
+  methods: {
+    setCount(direction, id) {
+      this.tempPerchasedPlan.map((plan) => {
+        if (plan.id === id) {
+          if (direction === 'decrease') {
+            if (this.isDisable(plan.id)) return
+            return plan.count--
+          }
+          plan.count++
+        }
+      })
+    },
+    isDisable(id) {
+      let isDisable = false
+      let total = 0
+      this.tempPerchasedPlan.map((plan) => {
+        total += plan.count
+        if (plan.id === id) {
+          isDisable = plan.count <= 0
+        }
+      })
+      if (total <= 1) return true
+      return isDisable
     },
   },
 }
@@ -94,6 +140,7 @@ export default {
   .form-row {
     display: flex;
     justify-content: space-between;
+    gap: 12px;
 
     &__head_title {
       flex: 1;
@@ -101,6 +148,12 @@ export default {
       &:first-child {
         flex: 3;
         max-width: 278px;
+      }
+
+      &_count {
+        display: flex;
+        justify-content: space-evenly;
+        align-items: center;
       }
     }
   }

--- a/components/UiMerchandiseList.vue
+++ b/components/UiMerchandiseList.vue
@@ -9,7 +9,7 @@
     <div class="merchandise-list-detail__form_devider" />
 
     <div
-      v-for="perchased in tempPerchasedPlan"
+      v-for="perchased in filteredPerchasedPlan"
       :key="perchased.id"
       class="merchandise-list-detail__form_content form-row"
     >
@@ -75,14 +75,10 @@ export default {
       type: Boolean,
       default: false,
     },
-  },
-  data() {
-    return {
-      tempPerchasedPlan: [],
-    }
-  },
-  created() {
-    this.tempPerchasedPlan = this.filteredPerchasedPlan
+    setCount: {
+      type: Function,
+      default: () => {},
+    },
   },
   computed: {
     filteredPerchasedPlan() {
@@ -93,31 +89,6 @@ export default {
       else {
         return this.perchasedPlan
       }
-    },
-  },
-  methods: {
-    setCount(direction, id) {
-      this.tempPerchasedPlan.map((plan) => {
-        if (plan.id === id) {
-          if (direction === 'decrease') {
-            if (this.isDisable(plan.id)) return
-            return plan.count--
-          }
-          plan.count++
-        }
-      })
-    },
-    isDisable(id) {
-      let isDisable = false
-      let total = 0
-      this.tempPerchasedPlan.map((plan) => {
-        total += plan.count
-        if (plan.id === id) {
-          isDisable = plan.count <= 0
-        }
-      })
-      if (total <= 1) return true
-      return isDisable
     },
   },
 }

--- a/components/UiMerchandiseList.vue
+++ b/components/UiMerchandiseList.vue
@@ -15,12 +15,7 @@
     >
       <div class="form-row__head_title">{{ perchased.detail }}</div>
       <div class="form-row__head_title">
-        <input
-          v-model="perchased.count"
-          type="number"
-          :min="showAll ? 0 : 1"
-          max="9"
-        />
+        {{ perchased.count }}
       </div>
       <div class="form-row__head_title">NT${{ perchased.newPrice }}</div>
     </div>

--- a/components/UiMerchandiseList.vue
+++ b/components/UiMerchandiseList.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="merchandise-list-detail">
+  <div class="merchandise-list-detail" :class="{ pop_up: isPopUp }">
     <div class="merchandise-list-detail__form_head form-row">
       <div class="form-row__head_title">品名</div>
       <div class="form-row__head_title">數量</div>
@@ -13,7 +13,7 @@
       :key="perchased.id"
       class="merchandise-list-detail__form_content form-row"
     >
-      <div class="form-row__head_title" :class="{ pop_up: isPopUp }">
+      <div class="form-row__head_title detail">
         {{ perchased.detail }}
       </div>
       <div class="form-row__head_title form-row__head_title_count">
@@ -150,6 +150,10 @@ export default {
         max-width: 278px;
       }
 
+      &:nth-child(2) {
+        text-align: center;
+      }
+
       &_count {
         display: flex;
         justify-content: space-evenly;
@@ -159,6 +163,9 @@ export default {
   }
   &__form_content {
     align-items: center;
+    &:not:not(:first-child):not(:last-child) {
+      margin-bottom: 16px;
+    }
     @include media-breakpoint-up(sm) {
       font-size: 18px;
     }
@@ -174,10 +181,16 @@ export default {
 }
 
 .pop_up {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
+  .detail {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+  }
+
+  .form-row:not(:first-child):not(:last-child) {
+    margin-bottom: 21px;
+  }
 }
 </style>

--- a/components/UiMerchandiseList.vue
+++ b/components/UiMerchandiseList.vue
@@ -13,7 +13,9 @@
       :key="perchased.id"
       class="merchandise-list-detail__form_content form-row"
     >
-      <div class="form-row__head_title">{{ perchased.detail }}</div>
+      <div class="form-row__head_title" :class="{ pop_up: isPopUp }">
+        {{ perchased.detail }}
+      </div>
       <div class="form-row__head_title">
         {{ perchased.count }}
       </div>
@@ -50,6 +52,10 @@ export default {
       },
     },
     showAll: {
+      type: Boolean,
+      default: false,
+    },
+    isPopUp: {
       type: Boolean,
       default: false,
     },
@@ -112,5 +118,13 @@ export default {
     border: 1px solid #00000080;
     margin-bottom: 18px;
   }
+}
+
+.pop_up {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
 }
 </style>

--- a/components/UiSubscribeCountButton.vue
+++ b/components/UiSubscribeCountButton.vue
@@ -1,0 +1,66 @@
+<template>
+  <div class="count-button" :class="{ disable: isDisable }">{{ symbol }}</div>
+</template>
+
+<script>
+export default {
+  props: {
+    type: {
+      type: String,
+      isRequired: true,
+      default: '',
+    },
+    isDisable: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  computed: {
+    symbol() {
+      return this.type === 'increase' ? '+' : '-'
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.count-button {
+  user-select: none;
+  cursor: pointer;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 17px;
+  line-height: 20px;
+  color: #054f77;
+  border-radius: 50%;
+  background: #ffffff;
+  border: 1px solid #054f77;
+
+  &:hover {
+    background: linear-gradient(
+        0deg,
+        rgba(5, 79, 119, 0.05),
+        rgba(5, 79, 119, 0.05)
+      ),
+      #ffffff;
+  }
+  &:active {
+    background: linear-gradient(
+        0deg,
+        rgba(5, 79, 119, 0.1),
+        rgba(5, 79, 119, 0.1)
+      ),
+      #ffffff;
+  }
+
+  &.disable {
+    cursor: not-allowed;
+    background: #e3e3e3;
+    border: 1px solid rgba(0, 0, 0, 0.2);
+    color: rgba(0, 0, 0, 0.2);
+  }
+}
+</style>


### PR DESCRIPTION
- 調整「訂購項目」 UI
- 修改 pop up（mobile web）若品項字數最多三行，超過在文末顯示 … 隱藏多的字
- 新增 `UiSubscribeCountButton`
- 拿掉修改 pop up 以外的數量調整功能
- 數量不得為零或被全部刪除

### 「確認修改」按鈕規則：（非該 PR 修改）
1. 一次只能選一個方案（一年 / 兩年）
2. 單個方案沒有數量上限
3. 不可以不選任何方案

### UiSubscribeCountButton 規則：
1. 數量沒有上限（ `+` 總是可以按）
2. 該方案 0 時不能再按 `-`
3. 兩個方案總共只有一份時，本來只有 1 的那個也不能按 `-`

## 參考資料：
- [卡片](https://app.asana.com/0/1200570778319695/1200581556792676)
- [文件](https://paper.dropbox.com/doc/--BOkkQe3P28cU7XeaNldlzRdbAg-jgnC27r3xclTCRRfCdqUi)
- [設計稿](https://www.figma.com/file/qmocxMBHG6D7T2VPdydRWG/%E9%8F%A1%E9%80%B1%E5%88%8A---%E7%B6%B2%E7%AB%99?node-id=3202%3A14412)