### PR TITLE
feat: receipt validation & fix: submit redirect path

### DIFF
--- a/components/SubscribeFormOrdererData.vue
+++ b/components/SubscribeFormOrdererData.vue
@@ -242,7 +242,7 @@ export default {
     check() {
       if (this.isNeedToCheck) {
         this.$v.$touch()
-        if (this.$v.$invalid) {
+        if (this.$v.$invalid || !this.isValidPhone) {
           this.submitStatus = 'ERROR'
         } else {
           this.submitStatus = 'OK'

--- a/components/SubscribeFormReceipt.vue
+++ b/components/SubscribeFormReceipt.vue
@@ -226,7 +226,10 @@ export default {
     receiptData: {
       handler(val) {
         this.setReceiptData(val)
-
+        if (val.receiptPlan !== '二聯式發票（含載具）') {
+          this.receiptData.carrierType = '請選擇'
+          this.receiptData.carrierNumber = ''
+        }
         // reset validation status after chagned value
         this.receiptFormStatus = {
           receiptPlan: 'OK',

--- a/components/UiValidationInput.vue
+++ b/components/UiValidationInput.vue
@@ -14,11 +14,11 @@
       :disabled="disable"
     />
 
-    <span
-      v-if="isNeedToCheck && !isValidCarrierUbn && this.value && hasChange"
-      class="error__message"
-      >請輸入有效的統一編號（8 碼）</span
-    >
+    <template v-if="isNeedToCheck && this.value && hasChange">
+      <span v-show="!isValidCarrierUbn" class="error__message"
+        >請輸入有效的統一編號（8 碼）</span
+      >
+    </template>
 
     <span
       v-else-if="!$v.value.required && $v.value.$error && isNeedToCheck"

--- a/pages/papermag/_plan/index.vue
+++ b/pages/papermag/_plan/index.vue
@@ -84,7 +84,7 @@ export default {
          */
         this.$store.dispatch('subscribe/updateReadyToPay', true)
 
-        this.$router.push(`/subscribe/redirect`)
+        this.$router.push(`/papermag/redirect`)
       } catch (err) {
         console.error(err)
 


### PR DESCRIPTION
- 若沒通過手機驗證，則無法送出
- 新增二聯式發票驗證，沒通過則顯示錯誤 & 無法送出
- 勾選其他發票方式後，二聯式發票單選清空，下方無法輸入
- 更改送出後重導的 url

### 參考資料：

- [文件](https://paper.dropbox.com/doc/--BOkkQe3P28cU7XeaNldlzRdbAg-jgnC27r3xclTCRRfCdqUi)
- [設計稿](https://www.figma.com/file/qmocxMBHG6D7T2VPdydRWG/%E9%8F%A1%E9%80%B1%E5%88%8A---%E7%B6%B2%E7%AB%99?node-id=3202%3A14412)