### PR TITLE
fix(generateCarrierInt): mail -> Email 載具

### DIFF
--- a/components/SubscribeForm.vue
+++ b/components/SubscribeForm.vue
@@ -244,7 +244,7 @@ export default {
       }
 
       switch (carrierType) {
-        case 'mail':
+        case 'Email 載具':
           return '2'
 
         case '手機條碼':


### PR DESCRIPTION
https://dev.mirrormedia.mg/papermag/1
在測試這頁的二聯式發票的時候，只有「Email 載具」無法正確寫入DB，其他自然人憑證、手機條碼都可以
試著找出問題並修正

中間如果手動在DB中加上代表Email載具的'2'，則後續處理正常
應該吧