### PR TITLE
fix: adjust papermag

### DIFF
--- a/components/SubscribeForm.vue
+++ b/components/SubscribeForm.vue
@@ -468,6 +468,9 @@ export default {
       color: rgba(0, 0, 0, 0.2);
       font-size: 18px;
       line-height: 25px;
+      &::placeholder {
+        color: rgb(227, 227, 227);
+      }
     }
 
     &::placeholder {

--- a/components/SubscribeFormPlanList.vue
+++ b/components/SubscribeFormPlanList.vue
@@ -20,16 +20,16 @@
             class="merchandise-list__discount_code_input"
             :class="{ focus: isInputFocused, disabled: discount.hasCode }"
           >
-            <label for="discount-code">MR000</label>
+            <label for="discount-code">MR</label>
             <input
               v-model="discount.code"
               type="text"
-              placeholder="12345"
+              placeholder="12345678"
               @focus="toggleIsInputFocused"
               @input="handleInput"
               @blur="toggleIsInputFocused"
               id="discount-code"
-              maxlength="5"
+              maxlength="8"
               :disabled="discount.hasCode"
             />
           </div>
@@ -131,7 +131,7 @@ export default {
       })
     },
     isDisabled() {
-      return this.discount.code.length !== 5
+      return this.discount.code.length !== 8
     },
     buttonTitle() {
       return this.discount.hasCode ? '移除' : '使用'

--- a/components/SubscribeFormPlanList.vue
+++ b/components/SubscribeFormPlanList.vue
@@ -45,7 +45,7 @@
           class="merchandise-list__discount_code_row"
         >
           <div class="merchandise-list__discount_code_prompt">
-            <p>折扣 80 元、贈送 1 期</p>
+            <p>折扣 80 元、贈送 {{ choosenPlanYear }} 期</p>
           </div>
         </div>
 
@@ -135,6 +135,15 @@ export default {
     },
     buttonTitle() {
       return this.discount.hasCode ? '移除' : '使用'
+    },
+    choosenPlanYear() {
+      let year = 1
+      this.perchasedPlan.forEach((plan) => {
+        if (plan.count > 0) {
+          year = plan.title === '一年方案' ? 1 : 2
+        }
+      })
+      return year
     },
   },
   methods: {

--- a/components/SubscribeFormReceipt.vue
+++ b/components/SubscribeFormReceipt.vue
@@ -2,8 +2,6 @@
   <div class="receipt">
     <h2 class="subscribe-form__title">電子發票</h2>
 
-    <p class="receipt__detail">發票將於付款成功後 7 個工作天內寄達。</p>
-
     <p
       v-show="isNeedToCheck && receiptFormStatus.receiptPlan === 'ERROR'"
       class="receipt__error"

--- a/components/SubscribeSuccessOrderInfo.vue
+++ b/components/SubscribeSuccessOrderInfo.vue
@@ -11,7 +11,7 @@
         <SubscribeSuccessOrderInfoContentRow
           v-if="orderInfo.discountPrice"
           title="續訂戶代碼"
-          :data="`MR000 ${orderInfo.discount_code}`"
+          :data="`MR ${orderInfo.discount_code}`"
         />
         <SubscribeSuccessOrderInfoContentRow
           title="訂單日期"


### PR DESCRIPTION
### 描述
- 續訂折扣碼輸入框格式改成輸入後 8 碼
- 我有續訂折扣碼的文字調整：選擇二年鏡週刊 104 期，應出現 "折扣 80 元，贈送 2 期" (目前顯示 "贈送 1 期" 有邏輯錯誤)
- 若訂購人沒輸入市話資料，打勾同收件人，市話欄位不應帶預設值 (目前會有內容)
- 電子發票底下的文字刪除 "發票將於付款成功後..."

### 參考資料
-[Asana卡片](https://app.asana.com/0/1200640136089459/1200683061054603/f)
