### PR TITLE
fix: subscribe UI and sim

### DIFF
--- a/components/SubscribeMembershipChoosePlanCard.vue
+++ b/components/SubscribeMembershipChoosePlanCard.vue
@@ -140,12 +140,14 @@ export default {
   &__button_group {
     display: flex;
     flex-direction: column;
-    gap: 12px;
 
     .subcribe-button {
       max-width: 100%;
       height: 71px;
       padding: 12px;
+      &:nth-child(2) {
+        margin-top: 12px;
+      }
     }
 
     &_hint_under_button {

--- a/pages/profile/purchase.vue
+++ b/pages/profile/purchase.vue
@@ -333,7 +333,7 @@ export default {
     padding: 0;
     @include media-breakpoint-up(md) {
       border: 1px solid rgba(0, 0, 0, 0.1);
-      padding: 24px 24px 16px 24px;
+      padding: 40px;
     }
 
     div {

--- a/pages/subscribe/success.vue
+++ b/pages/subscribe/success.vue
@@ -52,7 +52,9 @@
         </div>
       </div>
     </div>
-    <button class="sim" @click="toggleHasLink">toggle 顯示按鈕</button>
+    <button v-if="showSim" class="sim" @click="toggleHasLink">
+      toggle 顯示按鈕
+    </button>
   </section>
 </template>
 
@@ -63,6 +65,7 @@ import SubscribeSuccessOrderInfoContentRow from '~/components/SubscribeSuccessOr
 import MembershipFormPerchaseInfo from '~/components/MembershipFormPerchaseInfo.vue'
 import UiSubscribeButton from '~/components/UiSubscribeButton.vue'
 import UiMembershipButtonSecondary from '~/components/UiMembershipButtonSecondary.vue'
+import { ENV } from '~/configs/config'
 
 export default {
   setup() {
@@ -89,6 +92,11 @@ export default {
       orderDate: '2019-12-25',
       hasLink: false,
     }
+  },
+  computed: {
+    showSim() {
+      return ENV !== 'prod'
+    },
   },
   methods: {
     toggleHasLink() {


### PR DESCRIPTION
### 描述
- 成功頁（/subscribe/success）模擬器於正式機隱藏
- 解決方案選擇頁（/subscribe）按鈕於 safari 無法分開問題
- 調整訂閱紀錄頁（/profile/purchase）padding