### PR TITLE
style(ContainerStoryBody): brief color

### DIFF
--- a/components/ContainerStoryBody.vue
+++ b/components/ContainerStoryBody.vue
@@ -404,8 +404,7 @@ export {
 
   @each $name, $color in $sections-color {
     &.#{$name} {
-      .story__category::before,
-      .story__brief {
+      .story__category::before {
         background-color: $color;
       }
     }
@@ -500,7 +499,7 @@ export {
     font-size: 19.2px; // 1.2rem
     font-weight: 700;
     line-height: 36px;
-    background-color: #000;
+    background-color: rgba(5, 79, 119, 1);
     &::v-deep {
       .g-story-paragraph {
         color: #fff;


### PR DESCRIPTION
### 描述
- 更改文章前言顏色，統一改成藍色
- [設計稿](https://www.figma.com/file/qmocxMBHG6D7T2VPdydRWG/%E9%8F%A1%E9%80%B1%E5%88%8A---%E7%B6%B2%E7%AB%99?node-id=3305%3A11987)