### PR TITLE
feat: subscribe-info receipt email preset membership email

### DIFF
--- a/pages/subscribe/info.vue
+++ b/pages/subscribe/info.vue
@@ -388,6 +388,12 @@ export default {
       }
     },
   },
+  watch: {
+    'receiptData.carrierType'() {
+      if (this.receiptData.carrierType === '2')
+        this.receiptData.carrierNumber = this.$store.state.membership.userEmail
+    },
+  },
 }
 </script>
 


### PR DESCRIPTION
### 描述
- 會員訂閱確認訂購頁，填入**發票**email欄位需帶預設值，且可被更動