### PR TITLE
fix(login-page): resolve login error when route path is not exactly /login

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -553,6 +553,7 @@ module.exports = {
       routes.splice(originalLoginRouteIndex, 1)
       routes.push({
         path: '/login',
+        name: 'login',
         component: resolve(__dirname, 'pages/loginNew.vue'),
       })
 

--- a/store/membership.js
+++ b/store/membership.js
@@ -77,7 +77,7 @@ export const actions = {
     { dispatch, rootState },
     { authUser, mode = 'login', isNewUser = false }
   ) {
-    const isNotInLoginPage = this.app?.context?.route?.path !== '/login'
+    const isNotInLoginPage = this.app?.context?.route?.name !== 'login'
     if (isNotInLoginPage) return
 
     try {


### PR DESCRIPTION
Determine route name rather than route path, so that we can perform login when the route path is end with `/` like `/login/`.
ref: [Named Routes of Vue Router](https://router.vuejs.org/guide/essentials/named-routes.html)