### PR TITLE
fix: receipt input and email and css gap remove

### DIFF
--- a/components/MemberShipStatus.vue
+++ b/components/MemberShipStatus.vue
@@ -133,7 +133,9 @@ export default {
     &.mobile {
       flex-direction: column;
       align-items: flex-start;
-      gap: 12px;
+      div + div {
+        margin-top: 12px;
+      }
     }
     &_status {
       font-weight: 600;
@@ -141,11 +143,15 @@ export default {
       line-height: 25px;
       color: rgba(0, 0, 0, 0.66);
       display: flex;
-      gap: 4px;
+      img {
+        margin-left: 4px;
+      }
     }
     &_button_group {
       display: flex;
-      gap: 4px;
+      .button + .button {
+        margin-left: 4px;
+      }
       .button {
         padding: 8px 16px;
         font-size: 16px;

--- a/components/MembershipFormPerchaseInfo.vue
+++ b/components/MembershipFormPerchaseInfo.vue
@@ -59,7 +59,10 @@ export default {
     display: flex;
     justify-content: space-between;
     margin-bottom: 12px;
-    gap: 24px;
+
+    span + span {
+      margin-left: 24px;
+    }
 
     * {
       min-width: 70px;

--- a/components/MembershipPayRecord.vue
+++ b/components/MembershipPayRecord.vue
@@ -20,7 +20,7 @@
         class="pay-record__form_row load-more"
         @click="$emit('load-more-record')"
       >
-        展開更多
+        <span>展開更多</span>
         <img src="~/assets/arrow-down-default.svg" />
       </div>
     </div>
@@ -85,7 +85,9 @@ export default {
     }
     &_row {
       display: flex;
-      gap: 16px;
+      div + div {
+        margin-left: 16px;
+      }
       &:first-child {
         padding-bottom: 8px;
       }
@@ -108,9 +110,11 @@ export default {
       color: #054f77;
       justify-content: center;
       cursor: pointer;
-      gap: 2px;
       display: flex;
       width: auto;
+      img {
+        margin-left: 2px;
+      }
     }
   }
 }

--- a/components/MembershipPosts.vue
+++ b/components/MembershipPosts.vue
@@ -69,7 +69,9 @@ export default {
     }
     &_row {
       display: flex;
-      gap: 16px;
+      div + div {
+        margin-left: 16px;
+      }
       div {
         flex: 1;
         &:first-child {
@@ -99,9 +101,11 @@ export default {
       color: #054f77;
       justify-content: center;
       cursor: pointer;
-      gap: 2px;
       display: flex;
       width: auto;
+      img {
+        margin-left: 2px;
+      }
     }
   }
 }

--- a/components/SubscribeFormReceipt.vue
+++ b/components/SubscribeFormReceipt.vue
@@ -51,9 +51,9 @@
             :setReciptFormStatus="setReciptFormStatus"
             @handleChangeCarrierType="handleChangeCarrierType"
           />
-
           <UiValidationInput
             ref="carrierNumberDOM"
+            v-if="receiptData.carrierType && receiptData.carrierType < 2"
             v-model="receiptData.carrierNumber"
             :carrierType="receiptData.carrierType"
             :placeholder="carrierNumberPlaceHolder"
@@ -124,6 +124,10 @@ export default {
       type: Function,
       default: () => {},
     },
+    email: {
+      type: String,
+      default: '',
+    },
   },
   data() {
     return {
@@ -153,7 +157,7 @@ export default {
       let placeholder = ''
 
       switch (this.receiptData.carrierType) {
-        case '2': // 'Email 載具'
+        case '2': // '電子發票載具'
           placeholder = 'example@gmail.com'
           break
 
@@ -178,7 +182,7 @@ export default {
           value: '',
         },
         {
-          name: 'Email 載具',
+          name: '電子發票載具',
           value: '2',
         },
         {
@@ -227,6 +231,8 @@ export default {
         if (val.receiptPlan !== '二聯式發票（含載具）') {
           this.receiptData.carrierType = '請選擇'
           this.receiptData.carrierNumber = ''
+        } else if (this.receiptData.carrierType === '2') {
+          this.receiptData.carrierNumber = this.emailb
         }
         // reset validation status after chagned value
         this.receiptFormStatus = {
@@ -239,6 +245,11 @@ export default {
         }
       },
       deep: true,
+    },
+    email(newMail) {
+      if (this.receiptData.carrierType === '2') {
+        this.receiptData.carrierNumber = newMail
+      }
     },
   },
   methods: {

--- a/components/SubscribeMembershipChoosePlanCard.vue
+++ b/components/SubscribeMembershipChoosePlanCard.vue
@@ -130,7 +130,9 @@ export default {
       }
       li {
         display: flex;
-        gap: 5px;
+        img {
+          margin-right: 5px;
+        }
         & + li {
           padding-top: 12px;
           border-top: 1px solid rgba(0, 0, 0, 0.1);

--- a/components/UiMembershipList.vue
+++ b/components/UiMembershipList.vue
@@ -53,7 +53,9 @@ export default {
   .form-row {
     display: flex;
     justify-content: space-between;
-    gap: 12px;
+    div + div {
+      margin-left: 12px;
+    }
 
     &__head_title {
       flex: 2;
@@ -75,7 +77,9 @@ export default {
         display: flex;
         justify-content: flex-start;
         flex-direction: row-reverse;
-        gap: 4px;
+        div + div {
+          margin-right: 4px;
+        }
       }
 
       span {

--- a/components/UiMembershipPayRecordList.vue
+++ b/components/UiMembershipPayRecordList.vue
@@ -56,7 +56,9 @@ export default {
 <style lang="scss" scoped>
 .pay-list {
   display: flex;
-  gap: 20px;
+  div + div {
+    margin-left: 20px;
+  }
   &__content {
     flex: 1;
     @include media-breakpoint-up(sm) {
@@ -69,12 +71,17 @@ export default {
     }
     &_number {
       flex: 2;
-      gap: 4px;
+      div + div {
+        margin-left: 4px;
+      }
       @include media-breakpoint-up(sm) {
         display: flex;
         flex-direction: column;
         justify-content: flex-end;
         align-items: flex-start;
+        div + div {
+          margin-top: 4px;
+        }
       }
 
       &_type {

--- a/components/UiMerchandiseList.vue
+++ b/components/UiMerchandiseList.vue
@@ -137,7 +137,9 @@ export default {
   .form-row {
     display: flex;
     justify-content: space-between;
-    gap: 12px;
+    div + div {
+      margin-left: 12px;
+    }
 
     * {
       align-self: flex-start;

--- a/components/UiSubscribeSelect.vue
+++ b/components/UiSubscribeSelect.vue
@@ -50,7 +50,7 @@ export default {
       default: () => {
         return [
           {
-            name: 'email載具',
+            name: '電子發票載具',
             value: 'mail',
           },
           {

--- a/components/UiValidationInput.vue
+++ b/components/UiValidationInput.vue
@@ -96,7 +96,7 @@ export default {
           reg = /^[A-Z]{2}\d{14}$/
           result = reg.test(this.value)
           break
-        case 'Email 載具':
+        case '電子發票載具':
           result = this.$v.value.email
           break
         default:

--- a/pages/subscribe/info.vue
+++ b/pages/subscribe/info.vue
@@ -45,6 +45,7 @@
             :setReceiptData="setReceiptData"
             :validateOn="validateOn"
             :setFormStatus="setFormStatus"
+            :email="email"
           />
           <p
             v-if="!isUpgradeFromMonthToYear"
@@ -88,7 +89,7 @@ import SubscribeFormReceipt from '~/components/SubscribeFormReceipt.vue'
 import UiSubscribeButton from '~/components/UiSubscribeButton.vue'
 import { useMemberSubscribeMachine } from '~/xstate/member-subscribe/compositions'
 export default {
-  middleware: ['handle-go-to-marketing', 'handle-forbid-direct-navigate'],
+  // middleware: ['handle-go-to-marketing', 'handle-forbid-direct-navigate'],
   components: {
     SubscribeStepProgress,
     MembershipFormPlanList,
@@ -355,6 +356,7 @@ export default {
           buyerUBN: this.validReceiptData.carrierUbn,
           category: getCategory.bind(this)(),
         }
+        console.log(gateWayPayload)
       } else {
         // one_time
         const subscribePostId = this.perchasedPlan?.[0]?.id
@@ -371,6 +373,7 @@ export default {
           buyerUBN: this.validReceiptData.carrierUbn,
           category: getCategory.bind(this)(),
         }
+        console.log(gateWayPayload)
       }
 
       return await this.$getPaymentDataOfSubscription(gateWayPayload)

--- a/pages/subscribe/success.vue
+++ b/pages/subscribe/success.vue
@@ -216,16 +216,16 @@ export default {
       }
     }
 
-    .during {
-      flex-direction: column;
-      gap: 4px;
-      margin-top: 24px;
-      @include media-breakpoint-up(sm) {
-        flex-direction: row;
-        gap: 0px;
-        margin-top: 12px;
-      }
-    }
+    // .during {
+    //   flex-direction: column;
+    //   gap: 4px;
+    //   margin-top: 24px;
+    //   @include media-breakpoint-up(sm) {
+    //     flex-direction: row;
+    //     gap: 0px;
+    //     margin-top: 12px;
+    //   }
+    // }
 
     &_button {
       display: flex;


### PR DESCRIPTION
### 描述
- 會員訂閱發票二聯式「Email 收據」改成「「電子發票載具」。
- 會員訂閱發票二聯式若「沒選」和「電子發票載具」皆不顯示 input，並自動帶入上方信箱。
- 考量 safari 相容性，將 css 中的 `gap` 改掉。
