### PR TITLE
feat: remove DFPads in topic article list when type is not timeline/group/portrait

### DIFF
--- a/deprecated/topic-page/Topic.vue
+++ b/deprecated/topic-page/Topic.vue
@@ -150,7 +150,7 @@
             :articles="autoScrollArticles"
             :hasDFP="false"
           />
-          <div class="ad">
+          <!-- <div class="ad">
             <vue-dfp
               :is="props.vueDfp"
               :pos="dfpPos"
@@ -160,7 +160,7 @@
               :unitId="mobileDfp"
               :size="getValue($store, 'getters.deprecatedStore.adSize')"
             />
-          </div>
+          </div> -->
           <article-list
             v-if="!isPresidentElectionId"
             v-show="hasAutoScroll"


### PR DESCRIPTION
- 需求 (Asana)：https://app.asana.com/0/1200896349481613/1201124118161034
- 描述：移除 `topic` 頁中 `type` 為 `list` 的頁中廣告。
- 補充：目前 `topic` 的分類只有 `timeline`、`group`、`protrait wall`、`list` 四種，在 `topic` 頁的分類中前三者有各自的版面，而 `list` 則被分在 v-else 中，因此若未來有新增 `type `類型，此次修改會被套用。

附錄：[type 為 list 實際文章範例](http://mirrormedia.tw/keystone/topics/614d27fb1347d20f00f112c5)