### PR TITLE
Feat cd with cloud build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,11 @@
+# buildtime
 node_modules
+cloudbuild.yaml
+
+# git
+.git
+.github
+.gitignore
+
+# style guide
+.prettierrc

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -57,13 +57,12 @@ steps:
       - push
       - gcr.io/$PROJECT_ID/mirror-media-nuxt:${BRANCH_NAME}_${SHORT_SHA}_${BUILD_ID}
   - id: trigger_deployment
-    name: curl
+    name: curlimages/curl
+    entrypoint: /bin/sh
     args:
-      - "-d"
-      - '{ "branch": "${BRANCH_NAME}", "build": { "cluster": "${_KUBERNETES_CLUSTER}", "root": "${_KUSTOMIZATION_ROOTS//STAGE/${BRANCH_NAME}", "image": { "root": "${_KUSTOMIZATION_IMAGE_ROOT//STAGE/${BRANCH_NAME}", "name: "${_KUSTOMIZATION_IMAGE_NAME}", "newname": "$gcr.io/$PROJECT_ID/mirror-media-nuxt:${BRANCH_NAME}_${SHORT_SHA}_${BUILD_ID}" } } }'
-      - "-X"
-      - "POST"
-      - "${_CD_WEBOOK_URL}?key=${_API_KEY}&secret=$$WEBHOOK_SECRET"
+      - -c
+      - >
+        curl --fail-with-body -H "application/json" -d '{ "branch": "${BRANCH_NAME}", "build": { "cluster": "${_KUBERNETES_CLUSTER}", "region": "${_KUBERNETES_COMPUTE_REGION}", "roots": "${_KUSTOMIZATION_ROOTS}", "image": { "root": "${_KUSTOMIZATION_IMAGE_ROOT}", "name": "${_KUSTOMIZATION_IMAGE_NAME}", "newname": "gcr.io/$PROJECT_ID/mirror-media-nuxt:${BRANCH_NAME}_${SHORT_SHA}_${BUILD_ID}" } } }' -X POST "${_CD_WEBOOK_URL}?key=${_API_KEY}&secret=$$WEBHOOK_SECRET"
     secretEnv: ["WEBHOOK_SECRET"]
 availableSecrets:
   secretManager:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -64,6 +64,7 @@ steps:
       - "-X"
       - "POST"
       - "${_CD_WEBOOK_URL}?key=${_API_KEY}&secret=$$WEBHOOK_SECRET"
+    secretEnv: ["WEBHOOK_SECRET"]
 availableSecrets:
   secretManager:
     - versionName: ${_CD_WEBHOOK_SECRET_VERSION}

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -56,5 +56,17 @@ steps:
     args:
       - push
       - gcr.io/$PROJECT_ID/mirror-media-nuxt:${BRANCH_NAME}_${SHORT_SHA}_${BUILD_ID}
+  - id: trigger_deployment
+    name: curl
+    args:
+      - "-d"
+      - '{ "branch": "${BRANCH_NAME}", "build": { "cluster": "${_KUBERNETES_CLUSTER}", "root": "${_KUSTOMIZATION_ROOTS//STAGE/${BRANCH_NAME}", "image": { "root": "${_KUSTOMIZATION_IMAGE_ROOT//STAGE/${BRANCH_NAME}", "name: "${_KUSTOMIZATION_IMAGE_NAME}", "newname": "$gcr.io/$PROJECT_ID/mirror-media-nuxt:${BRANCH_NAME}_${SHORT_SHA}_${BUILD_ID}" } } }'
+      - "-X"
+      - "POST"
+      - "${_CD_WEBOOK_URL}?key=${_API_KEY}&secret=$$WEBHOOK_SECRET"
+availableSecrets:
+  secretManager:
+    - versionName: ${_CD_WEBHOOK_SECRET_VERSION}
+      env: "WEBHOOK_SECRET"
 
 timeout: 1800s


### PR DESCRIPTION
Related topic: [Feat/add mirror media nuxt and new CD flow](https://github.com/mirror-media/kubernetes-configs/pull/79)

# What Changes
1. `.dockerignore` has ignored files related to cloud build, git, and style rules.
2. A `trigger_deployment` step is added to `cloudbuild.yaml` to trigger deployment. New variables are needed.
3. A secret is used to protect the webhook. It must be retrieved from `secretManager` and applied to shell agrs.

# Usage
Please see [mm-mirror-media-nuxt-CD](https://console.cloud.google.com/cloud-build/triggers/edit/f0b1dadf-a97f-4bce-bcc2-01fa177190cb?authuser=2&project=mirrormedia-1470651750304)