### PR TITLE
feat: premium loading skeleton

### DIFF
--- a/components/culture-post-for-premium/ContainerCulturePost.vue
+++ b/components/culture-post-for-premium/ContainerCulturePost.vue
@@ -62,6 +62,10 @@
         :content="post.content"
         :isArticleContentTruncatedByGateway="post.isTruncated"
         :pageState="articleBodyPageState"
+        :isLoading="isLoading"
+        :isFail="isFail"
+        :failTimes="failTimes"
+        @reload="handleReload"
       />
 
       <LazyRenderer
@@ -120,6 +124,20 @@ export default {
       type: Object,
       default: () => ({}),
       required: true,
+    },
+    isLoading: {
+      type: Boolean,
+      default: false,
+      required: true,
+    },
+    isFail: {
+      type: Boolean,
+      default: false,
+      required: true,
+    },
+    failTimes: {
+      type: Number,
+      default: 0,
     },
   },
 
@@ -303,6 +321,10 @@ export default {
       const { items = [] } = await this.$fetchImages({ id: imgIds })
 
       this.relatedImgs = items
+    },
+
+    handleReload() {
+      this.$emit('reload')
     },
   },
 

--- a/components/culture-post-for-premium/UiArticleBody.vue
+++ b/components/culture-post-for-premium/UiArticleBody.vue
@@ -3,9 +3,17 @@
     <article class="article-body">
       <UiPremiumBrief :brief="brief" />
       <ContentHandler v-for="item in content" :key="item.id" :item="item" />
+      <template v-if="pageState === 'premiumPageIsLogin'">
+        <UiArticleSkeleton v-show="isLoading" />
+      </template>
 
       <ClientOnly>
         <template v-if="pageState === 'premiumPageIsLogin'">
+          <UiReloadArticle
+            v-show="isFail"
+            :failTimes="failTimes"
+            @reload="handleReload"
+          />
           <div class="copyright-warning">
             <p>
               本新聞文字、照片、影片專供鏡週刊會員閱覽，未經鏡週刊授權，任何媒體、社群網站、論壇等均不得引用、改寫、轉貼，以免訟累。
@@ -37,12 +45,13 @@
       <template v-else>
         <div
           v-if="
-            isArticleContentTruncatedByGateway ||
-            (stateMembershipSubscribe &&
-              [
-                '會員訂閱功能.會員文章頁.未登入',
-                '會員訂閱功能.會員文章頁.已登入.未訂閱',
-              ].some(stateMembershipSubscribe.matches))
+            !failTimes &&
+            (isArticleContentTruncatedByGateway ||
+              (stateMembershipSubscribe &&
+                [
+                  '會員訂閱功能.會員文章頁.未登入',
+                  '會員訂閱功能.會員文章頁.已登入.未訂閱',
+                ].some(stateMembershipSubscribe.matches)))
           "
           class="invite-to-login-wrapper"
         >
@@ -70,6 +79,8 @@
 import ContentHandler from './ContentHandler.vue'
 import UiPremiumBrief from './UiPremiumBrief.vue'
 import UiPremiumInviteToLogin from '~/components/UiPremiumInviteToLogin.vue'
+import UiArticleSkeleton from '~/components/culture-post-for-premium/UiArticleSkeleton.vue'
+import UiReloadArticle from '~/components/culture-post-for-premium/UiReloadArticle.vue'
 import UiPremiumInviteToSubscribe from '~/components/UiPremiumInviteToSubscribe.vue'
 import { useMemberSubscribeMachine } from '~/xstate/member-subscribe/compositions'
 import { isMemberSubscribeFeatureToggled } from '~/xstate/member-subscribe/util'
@@ -82,6 +93,8 @@ export default {
     UiPremiumInviteToLogin,
     UiPremiumInviteToSubscribe,
     UiPremiumBrief,
+    UiArticleSkeleton,
+    UiReloadArticle,
   },
 
   setup() {
@@ -123,10 +136,27 @@ export default {
       type: Boolean,
       default: true,
     },
+    isLoading: {
+      type: Boolean,
+      default: false,
+      required: true,
+    },
+    isFail: {
+      type: Boolean,
+      default: false,
+      required: true,
+    },
+    failTimes: {
+      type: Number,
+      default: 0,
+    },
   },
   methods: {
     enterMagazinePage() {
       window.location.href = '/magazine/'
+    },
+    handleReload() {
+      this.$emit('reload')
     },
   },
 }

--- a/components/culture-post-for-premium/UiArticleSkeleton.vue
+++ b/components/culture-post-for-premium/UiArticleSkeleton.vue
@@ -1,0 +1,48 @@
+<template>
+  <div class="skeleton">
+    <div class="skeleton__line"></div>
+    <div class="skeleton__line"></div>
+    <div class="skeleton__line"></div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.skeleton {
+  margin: 32px 0;
+  &__line {
+    background: #d9d9d9;
+    border-radius: 4px;
+    height: 16px;
+    margin: 16px 0;
+    overflow: hidden;
+    position: relative;
+    &:last-child {
+      width: calc(100% - 60%);
+    }
+    &::before {
+      position: absolute;
+      content: '';
+      height: 100%;
+      width: 100%;
+      background-image: linear-gradient(
+        to right,
+        #d9d9d9 0%,
+        rgba(0, 0, 0, 0.05) 20%,
+        #d9d9d9 40%,
+        #d9d9d9 100%
+      );
+      background-repeat: no-repeat;
+      background-size: 450px 400px;
+      animation: shimmer 2s linear infinite;
+    }
+  }
+}
+@keyframes shimmer {
+  0% {
+    background-position: -450px 0;
+  }
+  100% {
+    background-position: 450px 0;
+  }
+}
+</style>

--- a/components/culture-post-for-premium/UiReloadArticle.vue
+++ b/components/culture-post-for-premium/UiReloadArticle.vue
@@ -1,0 +1,108 @@
+<template>
+  <div class="reload">
+    <div class="reload__background"></div>
+    <div class="reload__hint">
+      <p v-for="wording in hintWordings" :key="wording">{{ wording }}</p>
+    </div>
+    <div
+      v-if="!isFailMoreThanThreeTime"
+      class="reload__button"
+      @click="handleButtonClick"
+    >
+      重新載入
+    </div>
+    <a v-else class="reload__button" href="/section/member">回會員專區</a>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    failTimes: {
+      type: Number,
+      default: 0,
+    },
+  },
+  computed: {
+    isFailMoreThanThreeTime() {
+      return this.failTimes >= 3
+    },
+    hintWordings() {
+      const wording = this.isFailMoreThanThreeTime
+        ? ['抱歉！目前頁面暫時無法成功讀取', '我們將盡快修復']
+        : ['哎呀！讀取出了一點問題', '請重新整理頁面']
+      return wording
+    },
+  },
+  methods: {
+    handleButtonClick() {
+      this.$emit('reload')
+    },
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+.reload {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-bottom: 48px;
+  position: relative;
+  &__background {
+    position: absolute;
+    bottom: 100%;
+    width: 100vw;
+    height: 300px;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, white 80%);
+    left: -20px;
+    @include media-breakpoint-up(md) {
+      left: calc((100vw - 608px) / 2 * -1);
+    }
+    @include media-breakpoint-up(xl) {
+      width: 720px;
+      left: calc(((720px - 640px) / 2) * -1);
+    }
+  }
+  &__button {
+    padding: 12px 0px;
+    width: 327px;
+    height: 48px;
+    background: #ffffff;
+    border: 1px solid #054f77;
+    text-decoration: none !important;
+    border-radius: 2px;
+    font-size: 18px;
+    line-height: 25px;
+    color: #054f77 !important;
+    text-align: center;
+    cursor: pointer;
+    &:hover {
+      background: linear-gradient(
+          0deg,
+          rgba(5, 79, 119, 0.05),
+          rgba(5, 79, 119, 0.05)
+        ),
+        #ffffff;
+    }
+    &:active {
+      background: linear-gradient(
+          0deg,
+          rgba(5, 79, 119, 0.1),
+          rgba(5, 79, 119, 0.1)
+        ),
+        #ffffff;
+    }
+  }
+  &__hint {
+    text-align: center;
+    font-size: 16px;
+    line-height: 180%;
+    color: rgba(0, 0, 0, 0.5);
+    margin: 0 0 24px 0;
+    p + p {
+      margin-top: 8px;
+    }
+  }
+}
+</style>


### PR DESCRIPTION
### 描述
- 會員文章頁 loading skeleton。
- 點擊重新整理後，再打一次request。
- 當超過 3 次 request ，引導使用者至 `/section/member`。
- 在 query 新增 `mf=true` 可測試錯誤狀況。
- 新增模擬器，選擇是否要 reject request。

![](https://media3.giphy.com/media/aKGMaMb0n6zuhpQGfG/giphy.gif?cid=790b761188312f6382159dfad877d9303c861a0f1a6d3166&rid=giphy.gif&ct=g)
可透過勾選模擬器，決定下次是否要成功打到資料。

![](https://media.giphy.com/media/j7uYbem7PMT2Y734UL/giphy.gif)
錯誤超過三次，將使用者導回會員文章分類。

### 參考資料
- [設計稿](https://www.figma.com/file/qmocxMBHG6D7T2VPdydRWG/%E9%8F%A1%E9%80%B1%E5%88%8A---%E7%B6%B2%E7%AB%99?node-id=3305%3A13200)
- [Asana 卡片](https://app.asana.com/0/1201172801445084/1200527693908568)