### PR TITLE
refactor: set FETCH_BASIC_INFO with allMembers

### DIFF
--- a/apollo/queries/memberSubscriptionQuery.gql
+++ b/apollo/queries/memberSubscriptionQuery.gql
@@ -26,7 +26,7 @@ query fetchMemberSubscriptions($firebaseId: String!) {
   }
 }
 query fetchMemberBasicInfo($firebaseId: String!) {
-  member(where: { firebaseId: $firebaseId }) {
+  allMembers(where: { firebaseId: $firebaseId }) {
     id
     firebaseId
     email

--- a/store/membership-subscribe.js
+++ b/store/membership-subscribe.js
@@ -25,7 +25,7 @@ export const actions = {
 
     /*
      * we use "allMembers" query to fetch member in israfel
-     * if there's no result( which no error, allMembers.length = 0),
+     * if there's no result( which has no error, allMembers.length = 0),
      * then return custom error message "Can't find data in Israfel"
      */
     if (result?.data?.allMembers?.length) {

--- a/store/membership-subscribe.js
+++ b/store/membership-subscribe.js
@@ -13,30 +13,28 @@ export const mutations = {
 
 export const actions = {
   async FETCH_BASIC_INFO({ rootState, commit }) {
-    try {
-      const {
-        data,
-      } = await this.app.apolloProvider.clients.memberSubscription.query({
+    const result = await this.app.apolloProvider.clients.memberSubscription.query(
+      {
         fetchPolicy: 'no-cache',
         query: fetchMemberBasicInfo,
         variables: {
           firebaseId: rootState.membership.userUid,
         },
-      })
-
-      commit('SET_BASIC_INFO', data.member)
-    } catch (e) {
-      let error
-
-      if (
-        e.message === 'GraphQL error: You do not have access to this resource'
-      ) {
-        // custom Error to notify what happended exactly
-        error = new Error(
-          "GraphQL error: Can't find data in Israfel, please check if this member's data existed in Israfel"
-        )
-        throw error || e
       }
+    )
+
+    /*
+     * we use "allMembers" query to fetch member in israfel
+     * if there's no result( which no error, allMembers.length = 0),
+     * then return custom error message "Can't find data in Israfel"
+     */
+    if (result?.data?.allMembers?.length) {
+      const memberInfoData = result?.data?.allMembers?.[0]
+      commit('SET_BASIC_INFO', memberInfoData)
+    } else {
+      throw new Error(
+        "GraphQL error: Can't find data in Israfel, please check if this member's data existed in Israfel"
+      )
     }
   },
 }

--- a/store/membership.js
+++ b/store/membership.js
@@ -90,7 +90,7 @@ export const actions = {
         await createMemberDataInIsrafel.bind(this)()
       }
 
-      // step 3: fetch it data from israfel, them put it into Vuex
+      // step 3: fetch its data from israfel, them put it into Vuex
       const hasMemberAuthDataInVuex = rootState.membership.userUid
       if (hasMemberAuthDataInVuex) {
         // fetch member's basic info in Israfel
@@ -104,14 +104,25 @@ export const actions = {
       }
     } catch (error) {
       /*
-       * there are 2 error situation:
+       * there are 3 error situation:
        * 1: has firebase auth, but no member data in Israfel(login)
-       * 2: has created new firebase autn, but member email is duplicated (regiser)
-       * no metter what situation is,
-       * we still need to delete this member's firebase account
+       * 2: has created new firebase auth, but member email is duplicated (regiser)
+       * 3: some server error
+       * in situation 1 and 2:
+       * we need to delete this member's firebase account
+       * in situation3:
+       * do nothing with the firebase auth object
        */
-      const currentUser = this.$fire.auth.currentUser
-      currentUser?.delete()
+
+      if (
+        error.message ===
+          "GraphQL error: Can't find data in Israfel, please check if this member's data existed in Israfel" ||
+        error.message === "this member's email has been used in Israfel"
+      ) {
+        const currentUser = this.$fire.auth.currentUser
+
+        currentUser?.delete()
+      }
 
       // clear Vuex's authState
       await dispatch('SET_AUTH_STATE_TO_VUEX', { authUser: null })


### PR DESCRIPTION
### Notable changes
 set FETCH_BASIC_INFO with allMembers, 
 add some custom error message to determine whether is needed to delete firebase user or not
 
 ### 前情提要
 firebase auth在每一次的auth狀態變換時，都會呼叫`ON_AUTH_STATE_CHANGED_ACTION`
1.  將`firebase user`的資料放入Vuex（或是清空）
2.  如果Vuex中有`firebase user`，則抓取Israfel中的user資料並放入Vuex

而若是在pages/loginNew.vue頁面登入則會改呼叫`LOGIN_PAGE_ON_AUTH_STATE_CHANGED_ACTION`
1.  將`firebase user`的資料放入Vuex（只會是登入，所以`firebase user`必定有值）
2. 如果是register模式，抑或是第三方登入回傳的資訊判斷此user是新user，則在israfel中新建立改user的資料
3.  如果Vuex中有`firebase user`，則抓取Israfel中的user資料並放入Vuex

無論是上述哪個action的最後一步 都會從israfel中抓取member資料

### 問題所在
抓取member的query是`member`
這會造成「若israfel中沒有該user的資料，response會非常隱晦/難判斷」（`You do not have access  to this resource`）

因此此PR將query `member`改成`allMembers`
若無該user的資料 response將會是empty array
並以此為依據throw自定義的`Error（"GraphQL error: Can't find data in Israfel, please check if this member's data existed in Israfel"）`
 
 ### 藉由自定義的Error message來判斷是否要將firebase user給刪除
 在原有的code中 只要在login階段碰到error 都會回頭將`firebase user`給刪除
 但若是遇到500 server error的話
 就會發生誤刪的問題
 
 因此在此PR中 只有在Error message是：
-  ` "GraphQL error: Can't find data in Israfel, please check if this member's data existed in Israfel" `
-   ` "this member's email has been used in Israfel"`
上述兩種狀況才會刪除`firebase user`
 