### PR TITLE
feat: redirect /premiumsection/ to /section/member

### DIFF
--- a/components/UiHeaderSectionMemberListItem.vue
+++ b/components/UiHeaderSectionMemberListItem.vue
@@ -17,7 +17,7 @@
         <a
           :href="`${
             section.customPath !== null
-              ? '/' + (section.customPath || 'premiumsection')
+              ? '/' + (section.customPath || 'section/member')
               : ''
           }/${section.name}`"
           v-text="section.title"

--- a/components/culture-post-for-premium/UiArticleIndex.vue
+++ b/components/culture-post-for-premium/UiArticleIndex.vue
@@ -67,7 +67,7 @@
                   <a
                     :href="`${
                       section.customPath !== null
-                        ? '/' + (section.customPath || 'premiumsection')
+                        ? '/' + (section.customPath || 'section/member')
                         : ''
                     }/${section.name}`"
                     v-text="section.title"

--- a/pages/premiumsection/_name.vue
+++ b/pages/premiumsection/_name.vue
@@ -55,6 +55,10 @@ export default {
     this.listDataCurrentPage += 1
   },
 
+  mounted() {
+    if (!this.sectionData.id) this.$router.push('/section/member')
+  },
+
   data() {
     return {
       listData_: [],

--- a/pages/premiumsection/_name.vue
+++ b/pages/premiumsection/_name.vue
@@ -53,10 +53,7 @@ export default {
     this.setListData(response)
     this.setListDataTotal(response)
     this.listDataCurrentPage += 1
-  },
-
-  mounted() {
-    if (!this.sectionData.id) this.$router.push('/section/member')
+    if (!this.sectionData.id) this.$nuxt.context.redirect('/section/member')
   },
 
   data() {


### PR DESCRIPTION
### 描述
- 將原本導向 `premiumsection/` 的頁面改成 `section/member`
- 若 `premiumsection/_name` 抓不到 section 資料，也導向 `section/member`

### 問題
- 在 `mounted()` 階段導頁面是否太慢？但 `fetch()` 時似乎無法保證能抓到 `$store` 中的資料

### 參考資料
- [Asana 卡片](https://app.asana.com/0/1201364163068160/1201357467359899)