### PR TITLE
style(SubscribeForm): button words should be  white

### DIFF
--- a/components/SubscribeForm.vue
+++ b/components/SubscribeForm.vue
@@ -529,4 +529,8 @@ export default {
     }
   }
 }
+
+.subcribe-button span {
+  color: #fff !important;
+}
 </style>


### PR DESCRIPTION
### 描述
- 紙本雜誌訂閱確認訂購頁按鈕修正
因為和會員訂閱頁共用按鈕，也不是 button 本身造成顏色錯誤，故不修改 button component ，而將 css 寫在 `SubscribeForm` 內。

### 參考資料
- [Asana 卡片](https://app.asana.com/0/1201420194717706/1201125208252202)