### PR TITLE
feat: remove fetchPosts and redirect to fetchPostsFromMembershipGateway

### DIFF
--- a/pages/author/_id.vue
+++ b/pages/author/_id.vue
@@ -43,7 +43,7 @@ export default {
   },
   methods: {
     async fetchList(page) {
-      return await this.$fetchPosts({
+      return await this.$fetchPostsFromMembershipGateway({
         maxResults: 9,
         sort: '-publishedDate',
         $or: [

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -419,7 +419,7 @@ export default {
   methods: {
     async fetchFlashNews() {
       const { items: articles = [] } =
-        (await this.$fetchPosts({
+        (await this.$fetchPostsFromMembershipGateway({
           categories: [
             CATEGORY_ID_POLITICAL,
             CATEGORY_ID_CITY_NEWS,

--- a/pages/service-rule.vue
+++ b/pages/service-rule.vue
@@ -45,7 +45,7 @@ export default {
     }
 
     const [postResponse] = await Promise.allSettled([
-      this.$fetchPosts({
+      this.$fetchPostsFromMembershipGateway({
         slug: 'service-rule',
         isAudioSiteOnly: false,
         clean: 'content',

--- a/plugins/requests/index.js
+++ b/plugins/requests/index.js
@@ -226,9 +226,9 @@ export default (context, inject) => {
     fetchApiData(`/partners${buildParams(params)}`)
   )
 
-  inject('fetchPosts', (params) =>
-    fetchApiData(`/getposts${buildParams(params)}`)
-  )
+  // inject('fetchPosts', (params) =>
+  //   fetchApiData(`/getposts${buildParams(params)}`)
+  // )
   inject('fetchPostsFromMembershipGateway', (params, token) =>
     fetchApiData(`/getposts${buildParams(params)}`, true, token)
   )


### PR DESCRIPTION
### 描述
- 阻止FE api endpoint 簡單拿到全文，判斷有 /api/v2/getpost 時，改打gateway
- 有改的頁面：首頁、會員條款、作者頁

### 參考資料
- [Asana 卡片](https://app.asana.com/0/1201490633457579/1200527693908578)