### PR TITLE
feat(full-sc-ad): adjust style of close button and change z-index from 999 to 1200

### DIFF
--- a/components/UiFullScreenAd.vue
+++ b/components/UiFullScreenAd.vue
@@ -56,7 +56,7 @@ export default {
     left: 0;
     right: 0;
     bottom: 0;
-    z-index: 999;
+    z-index: 1200;
     display: flex;
     justify-content: center;
     align-items: center;
@@ -73,7 +73,7 @@ export default {
     position: fixed;
     right: 0;
     bottom: 0;
-    z-index: 999;
+    z-index: 1200;
   }
 
   &__btn {
@@ -83,7 +83,9 @@ export default {
     width: 32px;
     height: 32px;
     padding: 5px;
-    border: 2px solid rgba(255, 255, 255, 0.7);
+    border: 2px solid rgba(255, 255, 255, 0.9);
+    box-shadow: 2px 2px 5px #d3d3d3;
+    background-color: #d3d3d3;
   }
 }
 </style>


### PR DESCRIPTION
- 描述
1. 調整蓋板廣告 FS 的關閉按鈕樣式，以避免在白底廣告中不明顯。
2. 將蓋板廣告的 z-index 由 999 上調為 1200，以確保蓋板廣告保持在最上層。

- 需求
[Asana 卡片](https://app.asana.com/0/1201617285674159/1201593585605135)