### PR TITLE
feat: change UI in category/section page for premium member

### DIFF
--- a/components/ContainerList.vue
+++ b/components/ContainerList.vue
@@ -1,6 +1,11 @@
 <template>
-  <div class="list">
-    <ContainerGptAd class="ad" :pageKey="gptAdPageKey" adKey="HD" />
+  <div class="list" :class="{ 'list--premium': isPremiumMember }">
+    <ContainerGptAd
+      class="ad"
+      :class="{ 'ad--premium': isPremiumMember }"
+      :pageKey="gptAdPageKey"
+      adKey="HD"
+    />
 
     <UiArticleList
       class="article-list"
@@ -104,6 +109,9 @@ export default {
   },
 
   computed: {
+    isPremiumMember() {
+      return this.$store?.getters?.['membership-subscribe/isPremiumMember']
+    },
     listItemsInFirstPage() {
       return this.listItems.slice(0, this.maxResults)
     },
@@ -125,6 +133,9 @@ export default {
   background-color: #f2f2f2;
   padding: 36px 0;
   overflow: hidden;
+  &--premium {
+    padding: 16px 0;
+  }
   @include media-breakpoint-up(md) {
     padding: 36px 25px 72px 25px;
   }
@@ -137,6 +148,9 @@ export default {
 
 .ad {
   margin: 20px auto;
+  &--premium {
+    margin: 0;
+  }
 }
 
 .article-list {

--- a/components/MicroAd.vue
+++ b/components/MicroAd.vue
@@ -1,5 +1,10 @@
 <template>
-  <div v-if="!IS_AD_DISABLE" :id="`compass-fit-${unitId}`" class="micro-ad" />
+  <div
+    v-if="!IS_AD_DISABLE"
+    :id="`compass-fit-${unitId}`"
+    class="micro-ad"
+    :class="{ 'micro-ad--premium': isPremiumMember }"
+  ></div>
 </template>
 
 <script>
@@ -19,7 +24,11 @@ export default {
       IS_AD_DISABLE,
     }
   },
-
+  computed: {
+    isPremiumMember() {
+      return this.$store?.getters?.['membership-subscribe/isPremiumMember']
+    },
+  },
   mounted() {
     this.insertScript()
   },

--- a/components/UiArticleCard.vue
+++ b/components/UiArticleCard.vue
@@ -3,6 +3,7 @@
     :href="href"
     :target="target"
     class="article"
+    :class="{ 'article--premium': isPremiumMember }"
     rel="noopener noreferrer"
     @click="handleClick"
   >
@@ -21,12 +22,21 @@
     </div>
     <div
       class="article__bottom-wrapper bottom-wrapper"
+      :class="{ 'bottom-wrapper--premium': isPremiumMember }"
       :style="{
         backgroundColor: infoBackgroundColor,
       }"
     >
-      <h1 v-text="infoTitle" />
-      <p v-text="infoDescription" />
+      <h1
+        class="bottom-wrapper__title"
+        :class="{ 'bottom-wrapper__title--premium': isPremiumMember }"
+        v-text="infoTitle"
+      />
+      <p
+        class="bottom-wrapper__text"
+        :class="{ 'bottom-wrapper__text--premium': isPremiumMember }"
+        v-text="infoDescription"
+      />
     </div>
   </a>
 </template>
@@ -85,6 +95,9 @@ export default {
     }
   },
   computed: {
+    isPremiumMember() {
+      return this.$store?.getters?.['membership-subscribe/isPremiumMember']
+    },
     showImgText() {
       return this.imgText && this.imgText !== ''
     },
@@ -99,10 +112,14 @@ export default {
 
 <style lang="scss" scoped>
 .article {
+  box-shadow: 5px 5px 5px #bcbcbc;
   cursor: pointer;
   height: 100%;
   display: flex;
   flex-direction: column;
+  &--premium {
+    box-shadow: none;
+  }
   &__bottom-wrapper {
     flex: 1 1 auto;
   }
@@ -110,6 +127,10 @@ export default {
     transition: all 0.3s ease-in-out;
     &:hover {
       transform: translateY(-20px);
+      box-shadow: 5px 5px 5px #bcbcbc;
+    }
+    &--premium:hover {
+      box-shadow: none;
     }
   }
 }
@@ -158,13 +179,25 @@ export default {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  h1 {
+  &--premium {
+    padding: 20px 20px 36px;
+    @include media-breakpoint-up(md) {
+      padding: 20px;
+    }
+  }
+  &__title {
     font-size: 20.8px;
     font-weight: 300;
     color: #34495e;
     line-height: 1.3;
+    &--premium {
+      color: #054f77;
+      font-size: 18px;
+      font-weight: 400;
+      line-height: 25px;
+    }
   }
-  p {
+  &__text {
     font-size: 16px;
     font-weight: 300;
     color: #999;
@@ -175,6 +208,13 @@ export default {
     display: -webkit-box;
     -webkit-box-orient: vertical;
     overflow: hidden;
+    &--premium {
+      color: #979797;
+      margin: 20px 0 0 0;
+      @include media-breakpoint-up(md) {
+        margin: 36px 0 0 0;
+      }
+    }
   }
 }
 </style>

--- a/components/UiArticleList.vue
+++ b/components/UiArticleList.vue
@@ -11,7 +11,14 @@
     >
       {{ listTitle }}
     </h1>
-    <ol v-if="showList" class="list-wrapper__list list">
+    <ol
+      v-if="showList"
+      class="list-wrapper__list list"
+      :class="{
+        'list-wrapper__list--premium': isPremiumMember,
+        'list--premium': isPremiumMember,
+      }"
+    >
       <template v-for="(item, index) in listItems">
         <li :key="item.id" class="list__list-item">
           <UiArticleCard
@@ -107,9 +114,10 @@ export default {
   font-size: 24px;
   font-weight: 400;
   &--premium {
-    font-size: 20.8px;
+    margin: 0 16px 16px 16px;
+    font-size: 16px;
     line-height: 115%;
-    font-weight: 600;
+    font-weight: 500;
   }
   &.tag--premium {
     background: #c4c4c4;
@@ -118,11 +126,16 @@ export default {
   }
   @include media-breakpoint-up(md) {
     margin: 0 16px;
+    &--premium {
+      margin: 0 0 16px 0;
+      font-size: 20.8px;
+      font-weight: 600;
+    }
   }
   @include media-breakpoint-up(xl) {
     margin: 0;
     &--premium {
-      margin-top: 40px;
+      margin: 40px 0 16px;
     }
     &.tag--premium {
       margin-top: 28px;
@@ -132,6 +145,9 @@ export default {
 .list-wrapper {
   &__list {
     margin: 20px 0 0 0;
+    &--premium {
+      margin: 16px 0 0 0;
+    }
   }
 }
 
@@ -146,6 +162,9 @@ export default {
   }
   @include media-breakpoint-up(md) {
     margin: -20px 0 0 -20px;
+    &--premium {
+      margin: -36px 0 0 -20px;
+    }
     &__list-item {
       width: calc(50% - 20px);
       margin: 40px 0 0 20px;

--- a/css/micro-ad/listing.scss
+++ b/css/micro-ad/listing.scss
@@ -1,11 +1,12 @@
 .micro-ad {
   height: 100%;
-  background-color: #f4f1e9;
+  background-color: #f4f1e9;  
+  box-shadow: 5px 5px 5px #bcbcbc;
   @include media-breakpoint-up(xl) {
     transition: all 0.3s ease-in-out;
-
     &:hover {
       transform: translateY(-20px);
+      box-shadow: 5px 15px 5px #bcbcbc;
     }
   }
 
@@ -78,6 +79,41 @@
           word-wrap: break-word;
           -webkit-line-clamp: 3;
           overflow: hidden;
+        }
+      }
+    }
+  }
+}
+
+.micro-ad--premium {
+  background-color: #F3F1E9;
+  box-shadow: none;
+    &:hover {
+      box-shadow: none;
+  }
+
+  &::v-deep {
+   
+    #compass-fit-widget-content {
+
+      .listArticleBlock__content {
+        padding: 20px 20px 36px;
+        @include media-breakpoint-up(md) {
+          padding: 20px;
+        }
+        h2 {
+          color: #054f77;
+          font-size: 18px;
+          font-weight: 400;
+          line-height: 25px;
+        }
+
+        p {
+          color: #979797;
+          margin: 20px 0 0 0;
+          @include media-breakpoint-up(md) {
+            margin: 36px 0 0 0;
+          }
         }
       }
     }


### PR DESCRIPTION
做了兩個改動， ae9ad544ce5506e6482c43d2155e793375cb8af6 為調整css樣式（margin padding 字體等），
而 b9ba31bbef43d674fbaa82f46b5f69ba4d34eca3 則是在元件 MircoAd.vue上，加入`:class="{ 'micro-ad--premium': isPremiumMember }"`，判斷是否為premium member，若是的話則採用css/micro-ad/listing.scss 中的 `.micro-ad--premium`。
如此元件MircoAd.vue樣式，仍統一管理在listing.scss，也可以避免原有的樣式（`.micro-ad`）被更動。

以上，麻煩協助code review，謝謝。
