### PR TITLE
refactor: introduce UiSubtitleNavigator component and adjust existing component

### DIFF
--- a/components/culture-post-for-premium/ContainerCulturePost.vue
+++ b/components/culture-post-for-premium/ContainerCulturePost.vue
@@ -21,10 +21,16 @@
         :items="indexes"
         :currentIndex="currentIndex"
         :isIndexActive="isIndexActive"
+        :detectCurrentIndex="detectCurrentIndex"
         @closeIndex="handleIndexActive(false)"
         @openIndex="handleIndexActive(true)"
       />
-      <UiSubTitleNavigator class="subtitle-navigator" :items="indexes" />
+      <UiSubTitleNavigator
+        class="subtitle-navigator"
+        :items="indexes"
+        :currentIndex="currentIndex"
+        :detectCurrentIndex="detectCurrentIndex"
+      />
       <UiLanding
         :shouldShowMemberLabel="true"
         :sectionLabel="post.sectionLabelFirst"
@@ -298,13 +304,6 @@ export default {
   },
 
   methods: {
-    handleIndexClick(id) {
-      // this.$emit('closeIndex')
-      this.$scrollTo(`#header-${id}`, 500, {
-        lazy: false,
-        offset: -64,
-      })
-    },
     detectCurrentIndex() {
       import('intersection-observer').then(() => {
         const selectorIdBeginWithHeader = '[id^=header]'
@@ -331,7 +330,6 @@ export default {
             }
           )
         }
-
         targets.forEach((element) => {
           observer.observe(element)
         })

--- a/components/culture-post-for-premium/ContainerCulturePost.vue
+++ b/components/culture-post-for-premium/ContainerCulturePost.vue
@@ -24,7 +24,7 @@
         @closeIndex="handleIndexActive(false)"
         @openIndex="handleIndexActive(true)"
       />
-
+      <UiSubTitleNavigator class="subtitle-navigator" :items="indexes" />
       <UiLanding
         :shouldShowMemberLabel="true"
         :sectionLabel="post.sectionLabelFirst"
@@ -108,13 +108,13 @@ import UiArticleIndex from './UiArticleIndex.vue'
 import UiListRelatedRedesign from './UiListRelatedRedesign.vue'
 import UiListRelated from './UiListRelated.vue'
 import UiArticleInfo from './UiArticleInfo.vue'
+import UiSubTitleNavigator from './UiSubtitleNavigator.vue'
 import UiLanding from '~/components/UiLanding.vue'
 import ContainerHeaderSectionMember from '~/components/ContainerHeaderSectionMember.vue'
 import UiWineWarning from '~/components/UiWineWarning.vue'
 import UiFooter from '~/components/UiFooter.vue'
 import UiShareLinksToggled from '~/components/UiShareLinksToggled.vue'
 import UiShareLinksHasCopyLink from '~/components/UiShareLinksHasCopyLink.vue'
-
 import { SITE_OG_IMG, SITE_TITLE, SITE_URL } from '~/constants/index'
 import { doesContainWineName } from '~/utils/article.js'
 
@@ -127,6 +127,7 @@ export default {
     ContainerHeaderSectionMember,
     UiArticleBody,
     UiArticleIndex,
+    UiSubTitleNavigator,
     UiListRelatedRedesign,
     UiListRelated,
     UiWineWarning,
@@ -297,6 +298,13 @@ export default {
   },
 
   methods: {
+    handleIndexClick(id) {
+      // this.$emit('closeIndex')
+      this.$scrollTo(`#header-${id}`, 500, {
+        lazy: false,
+        offset: -64,
+      })
+    },
     detectCurrentIndex() {
       import('intersection-observer').then(() => {
         const selectorIdBeginWithHeader = '[id^=header]'
@@ -332,7 +340,6 @@ export default {
     handleIndexActive(isActive) {
       this.isIndexActive = isActive
     },
-
     async fetchRelatedImgs() {
       const imgIds = this.relateds.map((item) => item.heroImage)
       const { items = [] } = await this.$fetchImages({ id: imgIds })
@@ -440,6 +447,28 @@ export default {
 
 .article-index {
   z-index: 1;
+}
+.subtitle-navigator {
+  display: none;
+  @include media-breakpoint-up(xl) {
+    display: inline-block;
+    position: fixed;
+    top: 50%;
+    left: calc((100% - 634px) / 4);
+    right: auto;
+    bottom: auto;
+    transform: translate(-50%, -50%);
+    width: auto;
+    height: auto;
+  }
+  @include media-breakpoint-up(xxl) {
+    left: calc((100% - 1080px) / 4);
+    width: calc((100vw - 1080px) / 2 - 42px);
+    min-width: 139px;
+    max-width: 300px;
+    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+    padding: 15px 24px 16px;
+  }
 }
 
 .article-info {

--- a/components/culture-post-for-premium/UiArticleIndex.vue
+++ b/components/culture-post-for-premium/UiArticleIndex.vue
@@ -147,18 +147,6 @@ export default {
         : enableBodyScroll(this.$refs.indexContainer)
     },
   },
-
-  methods: {
-    /*
-     * handleIndexClick(id) {
-     *   this.$emit('closeIndex')
-     *   this.$scrollTo(`#header-${id}`, 500, {
-     *     lazy: false,
-     *     offset: -64,
-     *   })
-     * },
-     */
-  },
 }
 </script>
 

--- a/components/culture-post-for-premium/UiArticleIndex.vue
+++ b/components/culture-post-for-premium/UiArticleIndex.vue
@@ -20,6 +20,8 @@
           <UiSubtitleNavigator
             class="subtitle-navigator"
             :items="items"
+            :currentIndex="currentIndex"
+            :detectCurrentIndex="detectCurrentIndex"
             @closeIndex="$emit('closeIndex')"
           />
         </div>
@@ -95,6 +97,11 @@ export default {
   },
 
   props: {
+    detectCurrentIndex: {
+      type: Function,
+      required: true,
+      default: () => {},
+    },
     items: {
       type: Array,
       required: true,
@@ -212,15 +219,6 @@ export default {
     @include media-breakpoint-up(md) {
       width: 78.125%;
     }
-    @include media-breakpoint-up(xl) {
-      overflow-y: hidden;
-      width: 244px;
-      position: static;
-      padding: 0;
-      background-color: transparent;
-    }
-    @include media-breakpoint-up(xxl) {
-    }
   }
 }
 
@@ -230,63 +228,6 @@ export default {
     padding: 0;
   }
 }
-
-// .index-list {
-//   display: inline-block;
-
-//   + * {
-//     margin-top: 48px;
-//   }
-
-//   ul {
-//     display: inline-flex;
-//     flex-direction: column;
-//     align-items: flex-start;
-//     width: 100%;
-//     margin: 0;
-//     padding: 0;
-//     @include media-breakpoint-up(xl) {
-//       width: 240px;
-//     }
-//     @include media-breakpoint-up(xxl) {
-//       width: auto;
-//       list-style-type: disc;
-//       list-style-position: inside;
-//     }
-//     li {
-//       color: #404040de;
-//       display: inline;
-//       font-family: source-han-serif-tc, 'Songti TC', serif;
-//       font-size: 18px;
-//       line-height: 1.5;
-//       font-weight: 700;
-//       cursor: pointer;
-//       @include media-breakpoint-up(xxl) {
-//         display: list-item;
-//         font-size: 16px;
-//         &::before {
-//           content: '';
-//           display: inline-block;
-//           margin: 0 0 0 -8px;
-//         }
-//         &::marker {
-//           color: #404040de;
-//         }
-//       }
-
-//       &.active a {
-//         border-bottom: solid 2px #dec5a2;
-//         @include media-breakpoint-up(xxl) {
-//           border-bottom: 2px solid #1d9fb8;
-//         }
-//       }
-
-//       + li {
-//         margin-top: 19px;
-//       }
-//     }
-//   }
-// }
 
 .top {
   margin: auto 0;

--- a/components/culture-post-for-premium/UiArticleIndex.vue
+++ b/components/culture-post-for-premium/UiArticleIndex.vue
@@ -11,35 +11,17 @@
     </button>
 
     <div class="index__curtain" @click.self="$emit('closeIndex')">
-      <div
-        ref="indexContainer"
-        :class="[
-          'index-container',
-          { 'index-container--hidden-in-xl-viewport': items.length === 0 },
-        ]"
-      >
+      <div ref="indexContainer" class="index-container">
         <button class="index__btn close" @click="$emit('closeIndex')">
           <SvgClose />
         </button>
 
         <div :class="['top', { 'top--hidden': bottomStyle === 'white' }]">
-          <div v-if="items.length > 0" class="index-list">
-            <ul>
-              <li
-                v-for="(item, index) in items"
-                :key="item.id"
-                :class="{ active: currentIndex === index + 1 }"
-              >
-                <!-- eslint-disable vue/no-v-html -->
-                <a
-                  :href="`#header-${item.id}`"
-                  @click="handleIndexClick(item.id)"
-                  v-html="item.content"
-                />
-                <!-- eslint-enable vue/no-v-html -->
-              </li>
-            </ul>
-          </div>
+          <UiSubtitleNavigator
+            class="subtitle-navigator"
+            :items="items"
+            @closeIndex="$emit('closeIndex')"
+          />
         </div>
         <div
           v-if="isCurrentPagePremium"
@@ -102,13 +84,14 @@
 
 <script>
 import { disableBodyScroll, enableBodyScroll } from 'body-scroll-lock'
+import UiSubtitleNavigator from './UiSubtitleNavigator.vue'
 import SvgClose from '~/assets/premium-header-sidebar-hide.svg?inline'
 
 export default {
   name: 'UiArticleIndex',
-
   components: {
     SvgClose,
+    UiSubtitleNavigator,
   },
 
   props: {
@@ -166,13 +149,15 @@ export default {
   },
 
   methods: {
-    handleIndexClick(id) {
-      this.$emit('closeIndex')
-      this.$scrollTo(`#header-${id}`, 500, {
-        lazy: false,
-        offset: -64,
-      })
-    },
+    /*
+     * handleIndexClick(id) {
+     *   this.$emit('closeIndex')
+     *   this.$scrollTo(`#header-${id}`, 500, {
+     *     lazy: false,
+     *     offset: -64,
+     *   })
+     * },
+     */
   },
 }
 </script>
@@ -224,21 +209,6 @@ export default {
     width: 100%;
     height: 100%;
     background-color: rgba(#000, 0.8);
-
-    @include media-breakpoint-up(xl) {
-      display: inline-block;
-      top: 50%;
-      left: calc((100% - 634px) / 4);
-      right: auto;
-      bottom: auto;
-      transform: translate(-50%, -50%);
-      background-color: transparent;
-      width: auto;
-      height: auto;
-    }
-    @include media-breakpoint-up(xxl) {
-      left: calc((100% - 1080px) / 4);
-    }
   }
 
   &-container {
@@ -260,17 +230,8 @@ export default {
       position: static;
       padding: 0;
       background-color: transparent;
-      &--hidden-in-xl-viewport {
-        display: none;
-      }
     }
     @include media-breakpoint-up(xxl) {
-      width: calc((100vw - 1080px) / 2 - 42px);
-      min-width: 139px;
-      max-width: 300px;
-      background: #f3f5f7;
-      box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
-      padding: 15px 24px 16px;
     }
   }
 }
@@ -282,62 +243,62 @@ export default {
   }
 }
 
-.index-list {
-  display: inline-block;
+// .index-list {
+//   display: inline-block;
 
-  + * {
-    margin-top: 48px;
-  }
+//   + * {
+//     margin-top: 48px;
+//   }
 
-  ul {
-    display: inline-flex;
-    flex-direction: column;
-    align-items: flex-start;
-    width: 100%;
-    margin: 0;
-    padding: 0;
-    @include media-breakpoint-up(xl) {
-      width: 240px;
-    }
-    @include media-breakpoint-up(xxl) {
-      width: auto;
-      list-style-type: disc;
-      list-style-position: inside;
-    }
-    li {
-      color: #404040de;
-      display: inline;
-      font-family: source-han-serif-tc, 'Songti TC', serif;
-      font-size: 18px;
-      line-height: 1.5;
-      font-weight: 700;
-      cursor: pointer;
-      @include media-breakpoint-up(xxl) {
-        display: list-item;
-        font-size: 16px;
-        &::before {
-          content: '';
-          display: inline-block;
-          margin: 0 0 0 -8px;
-        }
-        &::marker {
-          color: #404040de;
-        }
-      }
+//   ul {
+//     display: inline-flex;
+//     flex-direction: column;
+//     align-items: flex-start;
+//     width: 100%;
+//     margin: 0;
+//     padding: 0;
+//     @include media-breakpoint-up(xl) {
+//       width: 240px;
+//     }
+//     @include media-breakpoint-up(xxl) {
+//       width: auto;
+//       list-style-type: disc;
+//       list-style-position: inside;
+//     }
+//     li {
+//       color: #404040de;
+//       display: inline;
+//       font-family: source-han-serif-tc, 'Songti TC', serif;
+//       font-size: 18px;
+//       line-height: 1.5;
+//       font-weight: 700;
+//       cursor: pointer;
+//       @include media-breakpoint-up(xxl) {
+//         display: list-item;
+//         font-size: 16px;
+//         &::before {
+//           content: '';
+//           display: inline-block;
+//           margin: 0 0 0 -8px;
+//         }
+//         &::marker {
+//           color: #404040de;
+//         }
+//       }
 
-      &.active a {
-        border-bottom: solid 2px #dec5a2;
-        @include media-breakpoint-up(xxl) {
-          border-bottom: 2px solid #1d9fb8;
-        }
-      }
+//       &.active a {
+//         border-bottom: solid 2px #dec5a2;
+//         @include media-breakpoint-up(xxl) {
+//           border-bottom: 2px solid #1d9fb8;
+//         }
+//       }
 
-      + li {
-        margin-top: 19px;
-      }
-    }
-  }
-}
+//       + li {
+//         margin-top: 19px;
+//       }
+//     }
+//   }
+// }
 
 .top {
   margin: auto 0;

--- a/components/culture-post-for-premium/UiSubtitleNavigator.vue
+++ b/components/culture-post-for-premium/UiSubtitleNavigator.vue
@@ -1,0 +1,105 @@
+<template>
+  <div v-if="items.length > 0" class="subtitle-navigator__wrapper">
+    <ul>
+      <li
+        v-for="(item, index) in items"
+        :key="item.id"
+        :class="{ active: currentIndex === index + 1 }"
+      >
+        <!-- eslint-disable vue/no-v-html -->
+        <a
+          :href="`#header-${item.id}`"
+          @click="handleIndexClick(item.id)"
+          v-html="item.content"
+        />
+        <!-- eslint-enable vue/no-v-html -->
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'UiSubtitleNavigator',
+  props: {
+    items: {
+      type: Array,
+      required: true,
+    },
+  },
+  methods: {
+    handleIndexClick(id) {
+      this.$emit('closeIndex')
+      this.$scrollTo(`#header-${id}`, 500, {
+        lazy: false,
+        offset: -64,
+      })
+    },
+  },
+}
+</script>
+<style lang="scss" scoped>
+.subtitle-navigator__wrapper {
+  @include media-breakpoint-up(xl) {
+    background-color: transparent;
+  }
+  @include media-breakpoint-up(xxl) {
+    background-color: #f3f5f7;
+    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+    padding: 15px 24px 16px;
+  }
+
+  + * {
+    margin-top: 48px;
+  }
+
+  ul {
+    display: inline-flex;
+    flex-direction: column;
+    align-items: flex-start;
+    width: 100%;
+    margin: 0;
+    padding: 0;
+    @include media-breakpoint-up(xl) {
+      width: 240px;
+    }
+    @include media-breakpoint-up(xxl) {
+      width: auto;
+      list-style-type: disc;
+      list-style-position: inside;
+    }
+    li {
+      color: #404040de;
+      display: inline;
+      font-family: source-han-serif-tc, 'Songti TC', serif;
+      font-size: 18px;
+      line-height: 1.5;
+      font-weight: 700;
+      cursor: pointer;
+      @include media-breakpoint-up(xxl) {
+        display: list-item;
+        font-size: 16px;
+        &::before {
+          content: '';
+          display: inline-block;
+          margin: 0 0 0 -8px;
+        }
+        &::marker {
+          color: #404040de;
+        }
+      }
+
+      &.active a {
+        border-bottom: solid 2px #dec5a2;
+        @include media-breakpoint-up(xxl) {
+          border-bottom: 2px solid #1d9fb8;
+        }
+      }
+
+      + li {
+        margin-top: 19px;
+      }
+    }
+  }
+}
+</style>

--- a/components/culture-post-for-premium/UiSubtitleNavigator.vue
+++ b/components/culture-post-for-premium/UiSubtitleNavigator.vue
@@ -26,7 +26,18 @@ export default {
       type: Array,
       required: true,
     },
+    currentIndex: {
+      type: Number,
+      default: 0,
+      required: true,
+    },
+    detectCurrentIndex: {
+      type: Function,
+      required: true,
+      default: () => {},
+    },
   },
+
   methods: {
     handleIndexClick(id) {
       this.$emit('closeIndex')
@@ -34,6 +45,7 @@ export default {
         lazy: false,
         offset: -64,
       })
+      this.detectCurrentIndex()
     },
   },
 }


### PR DESCRIPTION
此PR為將既有的元件 `UiArticleIndex` 中，分出小標的導覽器（這邊取名為`UiSubtitleNavigator`），作為一個獨立的元件。
`UiSubtitleNavigator` 用於兩處：
1. 直接用在 `ContainerCulturePost.vue`中，並在瀏覽器寬度>1200時顯示於文章左側。
2. 用於`UiArticleIndex`中，並於瀏覽器寬度<1200時，顯示於該元件的上方。

`ContainerCulturePost.vue`中僅規定`UiSubtitleNavigator`的位置與長寬，而字體、間距顏色等，則寫在`UiSubtitleNavigator`中，以便後續若要重用該元件，可以減少所需改動。

`UiArticleIndex`中的css有點亂，（比如`.index__curtain`與`.index_container`，這兩個命名有些模糊），日後有時間應該會在重構。

而關於props、emit的改動，目前仍是採用「當子元件函式執行時，將某狀態emit出去，並觸發父元件的另一函式」。比如說這邊就是在`UiSubtitleNavigator`中觸發一[函式](https://github.com/mirror-media/mirror-media-nuxt/pull/529/commits/1ba326ac79628c71fd27d58a1995e45220d0ef5c#diff-042f3d37012ead8fcab3dc4192d97a27d7a1210ddc57c5c6b9e13946ffdc5f52R31-R37)，並將狀態傳遞至父元件。
會這樣寫的原因，主要是考量到既有程式碼多有使用emit，若冒然改為將全部函式統一管理在父元件，並向下傳遞，會降低程式碼的一致性，並可能有影響其他元件的風險存在。

以上