### PR TITLE
feat: add runtime config and client-side environment variable for fea…

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -595,4 +595,18 @@ module.exports = {
       })
     },
   },
+
+  /*
+   *  runtime config for feature toggle
+   *    if you decide to add certain environment variable when developing on local,
+   *    please add command to assign environment variable key and value,
+   *    which will temporarily add environment variable(or change value of existing environment variable)
+   *    until you break the program in execution.
+   *    for example:
+   *    $ CERTAIN_FEATURE_TOGGLE=on yarn dev
+   */
+
+  publicRuntimeConfig: {
+    noAdFeatureToggle: process.env.NO_AD_FEATURE_TOGGLE || 'off',
+  },
 }

--- a/store/index.js
+++ b/store/index.js
@@ -20,9 +20,12 @@ export const actions = {
 
       await dispatch('membership-subscribe/FETCH_BASIC_INFO')
     }
-
     const sectionsResponse = await dispatch('fetchGlobalData')
     commitSectionsData(commit, sectionsResponse)
+    commit(
+      'membership-subscribe/getFeatureToggleStatus',
+      app.$config.noAdFeatureToggle
+    )
   },
 
   async fetchGlobalData({ dispatch }) {

--- a/store/membership-subscribe.js
+++ b/store/membership-subscribe.js
@@ -1,15 +1,17 @@
 import Vue from 'vue'
 import mapValues from 'lodash/mapValues'
 import { fetchMemberBasicInfo } from '~/apollo/queries/memberSubscriptionQuery.gql'
-import { FEATURE_TOGGLE } from '~/configs/config'
-
 export const state = () => ({
   basicInfo: {},
+  noAdFeatureToggle: '',
 })
 
 export const mutations = {
   SET_BASIC_INFO(state, value = {}) {
     Vue.set(state, 'basicInfo', value)
+  },
+  getFeatureToggleStatus(state, featureToggle) {
+    state.noAdFeatureToggle = featureToggle
   },
 }
 
@@ -52,11 +54,10 @@ export function mapMemberTypeOfSubscribeGroupToMarketing(object) {
     return value
   })
 }
-
 export const getters = {
   isPremiumMember(state) {
     return (
-      FEATURE_TOGGLE === 'on' &&
+      state.noAdFeatureToggle === 'on' &&
       (state.basicInfo.type === 'subscribe_yearly' ||
         state.basicInfo.type === 'subscribe_monthly')
     )


### PR DESCRIPTION
…ture toggle

具體作法如下：

1. 在nuxt.config.js中新增[`publicRuntimeConfig`](https://github.com/mirror-media/mirror-media-nuxt/pull/538/commits/0f0eaaebb5e5ca55e7138f053c3d5a4844a6896a#diff-65d5d69bb59dcc81ad971719549cdee5018f0a240add8b7ef5c65bee3e73dae0R609-R611)，並新增一個變數`noAdFeatureToggle`，其值為環境變數`NO_AD_FEATURE_TOGGLE`，或是`"off"`。
2. 在/store/index.js中，[透過`nuxtServerInit`取得1.](https://github.com/mirror-media/mirror-media-nuxt/pull/538/commits/0f0eaaebb5e5ca55e7138f053c3d5a4844a6896a#diff-2886ae8dc0ffc0d351cc2e75fe977ac32d0067891113a6ec3c25c3761edb9633R25-R28)（位於`app.$config`中），並透過commit執行`/store/membership-subscribe.js`的mutation，[將`noAdFeatureToggle`寫入state](https://github.com/mirror-media/mirror-media-nuxt/pull/538/commits/0f0eaaebb5e5ca55e7138f053c3d5a4844a6896a#diff-bbf48e43acb436594d3b27ec29e48ab7ee28dabb179806ff581d145ac20d3a2dR13-R15)。
3. 透過`/store/membership-subscribe.js`的getter，計算是否為isPremiumMember。