### PR TITLE
feat(layouts, subscribe): add FB pixel in layout and subscribe page

### DIFF
--- a/components/UiPremiumInviteToSubscribe.vue
+++ b/components/UiPremiumInviteToSubscribe.vue
@@ -70,7 +70,7 @@ export default {
     },
     subscribePremium() {
       this.useCustomEventToFbPixel('Premium-subscribe-truncated')
-      window.fbq('trackCustom', 'Premium-subscribe-truncated')
+      this.$emit('subscribePremium')
     },
   },
 }

--- a/components/UiPremiumInviteToSubscribe.vue
+++ b/components/UiPremiumInviteToSubscribe.vue
@@ -45,11 +45,11 @@
 import UiMembershipButtonPrimary from '~/components/UiMembershipButtonPrimary.vue'
 import UiMembershipButtonLight from '~/components/UiMembershipButtonLight.vue'
 import UiPremiumLoginNow from '~/components/UiPremiumLoginNow.vue'
-import { sendCustomEventToFbPixel } from '~/composition/fb-pixel.js'
+import { useCustomEventToFbPixel } from '~/composition/fb-pixel.js'
 
 export default {
   setup() {
-    return { sendCustomEventToFbPixel }
+    return { useCustomEventToFbPixel }
   },
   components: {
     UiMembershipButtonPrimary,
@@ -64,12 +64,12 @@ export default {
   },
   methods: {
     subscribePost() {
-      this.sendCustomEventToFbPixel('Premium-subscribe-one-time-truncated')
+      this.useCustomEventToFbPixel('Premium-subscribe-one-time-truncated')
 
       this.$emit('subscribePost')
     },
     subscribePremium() {
-      this.sendCustomEventToFbPixel('Premium-subscribe-truncated')
+      this.useCustomEventToFbPixel('Premium-subscribe-truncated')
       window.fbq('trackCustom', 'Premium-subscribe-truncated')
     },
   },

--- a/components/UiPremiumInviteToSubscribe.vue
+++ b/components/UiPremiumInviteToSubscribe.vue
@@ -45,8 +45,12 @@
 import UiMembershipButtonPrimary from '~/components/UiMembershipButtonPrimary.vue'
 import UiMembershipButtonLight from '~/components/UiMembershipButtonLight.vue'
 import UiPremiumLoginNow from '~/components/UiPremiumLoginNow.vue'
+import { sendCustomEventToFbPixel } from '~/composition/fb-pixel.js'
 
 export default {
+  setup() {
+    return { sendCustomEventToFbPixel }
+  },
   components: {
     UiMembershipButtonPrimary,
     UiMembershipButtonLight,
@@ -60,12 +64,13 @@ export default {
   },
   methods: {
     subscribePost() {
-      window.fbq('trackCustom', 'Premium-subscribe-one-time-truncated')
+      this.sendCustomEventToFbPixel('Premium-subscribe-one-time-truncated')
+
       this.$emit('subscribePost')
     },
     subscribePremium() {
+      this.sendCustomEventToFbPixel('Premium-subscribe-truncated')
       window.fbq('trackCustom', 'Premium-subscribe-truncated')
-      this.$emit('subscribePremium')
     },
   },
 }

--- a/components/UiPremiumInviteToSubscribe.vue
+++ b/components/UiPremiumInviteToSubscribe.vue
@@ -11,7 +11,7 @@
             <UiMembershipButtonPrimary
               class="plan__button"
               data-user-behavior-description="premium-subscribe"
-              @click.native="$emit('subscribePremium')"
+              @click.native="subscribePremium"
             >
               加入Premium會員
             </UiMembershipButtonPrimary>
@@ -26,7 +26,7 @@
           <UiMembershipButtonLight
             class="plan__button"
             data-user-behavior-description="onetime-subscribe"
-            @click.native="$emit('subscribePost')"
+            @click.native="subscribePost"
           >
             解鎖單篇報導
           </UiMembershipButtonLight>
@@ -56,6 +56,16 @@ export default {
     shouldShowLoginNow: {
       type: Boolean,
       default: true,
+    },
+  },
+  methods: {
+    subscribePost() {
+      window.fbq('trackCustom', 'Premium-subscribe-one-time-truncated')
+      this.$emit('subscribePost')
+    },
+    subscribePremium() {
+      window.fbq('trackCustom', 'Premium-subscribe-truncated')
+      this.$emit('subscribePremium')
     },
   },
 }

--- a/composition/fb-pixel.js
+++ b/composition/fb-pixel.js
@@ -1,0 +1,15 @@
+import { onMounted, useStore } from '@nuxtjs/composition-api'
+function sendCustomEventToFbPixel(customEvent) {
+  window.fbq('trackCustom', customEvent)
+}
+
+function sendMemberPageViewToFbPixel() {
+  const { getters } = useStore()
+  const isLoggedIn = getters['membership/isLoggedIn']
+  onMounted(() => {
+    if (isLoggedIn) {
+      window.fbq('trackCustom', 'memberPageView')
+    }
+  })
+}
+export { sendCustomEventToFbPixel, sendMemberPageViewToFbPixel }

--- a/composition/fb-pixel.js
+++ b/composition/fb-pixel.js
@@ -1,9 +1,9 @@
 import { onMounted, useStore } from '@nuxtjs/composition-api'
-function sendCustomEventToFbPixel(customEvent) {
+function useCustomEventToFbPixel(customEvent) {
   window.fbq('trackCustom', customEvent)
 }
 
-function sendMemberPageViewToFbPixel() {
+function useMemberPageViewToFbPixel() {
   const { getters } = useStore()
   const isLoggedIn = getters['membership/isLoggedIn']
   onMounted(() => {
@@ -12,4 +12,4 @@ function sendMemberPageViewToFbPixel() {
     }
   })
 }
-export { sendCustomEventToFbPixel, sendMemberPageViewToFbPixel }
+export { useCustomEventToFbPixel, useMemberPageViewToFbPixel }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -25,7 +25,7 @@ import ContainerHeader from '~/components/ContainerHeader.vue'
 import UiFooter from '~/components/UiFooter.vue'
 import TheGdpr from '~/components/TheGdpr.vue'
 
-import { sendMemberPageViewToFbPixel } from '~/composition/fb-pixel.js'
+import { useMemberPageViewToFbPixel } from '~/composition/fb-pixel.js'
 import { useViewport } from '~/composition/viewport.js'
 import { fireActivationEvent } from '~/utils/google-optimize.js'
 
@@ -38,7 +38,7 @@ export default {
   },
   setup() {
     useViewport()
-    sendMemberPageViewToFbPixel()
+    useMemberPageViewToFbPixel()
   },
 
   async fetch() {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -25,6 +25,7 @@ import ContainerHeader from '~/components/ContainerHeader.vue'
 import UiFooter from '~/components/UiFooter.vue'
 import TheGdpr from '~/components/TheGdpr.vue'
 
+import { sendMemberPageViewToFbPixel } from '~/composition/fb-pixel.js'
 import { useViewport } from '~/composition/viewport.js'
 import { fireActivationEvent } from '~/utils/google-optimize.js'
 
@@ -37,6 +38,7 @@ export default {
   },
   setup() {
     useViewport()
+    sendMemberPageViewToFbPixel()
   },
 
   async fetch() {
@@ -78,22 +80,6 @@ export default {
 
   mounted() {
     fireActivationEvent.bind(this)()
-  },
-
-  head() {
-    return {
-      script: [
-        this.isLoggedIn
-          ? {
-              hid: 'facebookPixelMemberPageView',
-              innerHTML: `fbq('trackCustom', 'memberPageView');`,
-            }
-          : {},
-      ],
-      __dangerouslyDisableSanitizersByTagID: {
-        facebookPixelMemberPageView: ['innerHTML'],
-      },
-    }
   },
 }
 </script>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -45,8 +45,10 @@ export default {
       this.$store.dispatch('topics/fetchTopicsData'),
     ])
   },
-
   computed: {
+    isLoggedIn() {
+      return this.$store.getters['membership/isLoggedIn']
+    },
     isListing() {
       const listingRouteNames = [
         'section-name',
@@ -76,6 +78,22 @@ export default {
 
   mounted() {
     fireActivationEvent.bind(this)()
+  },
+
+  head() {
+    return {
+      script: [
+        this.isLoggedIn
+          ? {
+              hid: 'facebookPixelMemberPageView',
+              innerHTML: `fbq('trackCustom', 'memberPageView');`,
+            }
+          : {},
+      ],
+      __dangerouslyDisableSanitizersByTagID: {
+        facebookPixelMemberPageView: ['innerHTML'],
+      },
+    }
   },
 }
 </script>

--- a/layouts/empty.vue
+++ b/layouts/empty.vue
@@ -36,9 +36,28 @@ export default {
   components: {
     TheGdpr,
   },
-
+  computed: {
+    isLoggedIn() {
+      return this.$store.getters['membership/isLoggedIn']
+    },
+  },
   mounted() {
     fireActivationEvent.bind(this)()
+  },
+  head() {
+    return {
+      script: [
+        this.isLoggedIn
+          ? {
+              hid: 'facebookPixelMemberPageView',
+              innerHTML: `fbq('trackCustom', 'memberPageView');`,
+            }
+          : {},
+      ],
+      __dangerouslyDisableSanitizersByTagID: {
+        facebookPixelMemberPageView: ['innerHTML'],
+      },
+    }
   },
 }
 </script>

--- a/layouts/empty.vue
+++ b/layouts/empty.vue
@@ -13,11 +13,11 @@ import TheGdpr from '~/components/TheGdpr.vue'
 
 import { fireActivationEvent } from '~/utils/google-optimize.js'
 
-import { sendMemberPageViewToFbPixel } from '~/composition/fb-pixel.js'
+import { useMemberPageViewToFbPixel } from '~/composition/fb-pixel.js'
 export default {
   name: 'Empty',
   setup() {
-    sendMemberPageViewToFbPixel()
+    useMemberPageViewToFbPixel()
   },
   errorCaptured(error, vm, info) {
     if (vm.$route.name === 'premium-slug') {

--- a/layouts/empty.vue
+++ b/layouts/empty.vue
@@ -13,9 +13,12 @@ import TheGdpr from '~/components/TheGdpr.vue'
 
 import { fireActivationEvent } from '~/utils/google-optimize.js'
 
+import { sendMemberPageViewToFbPixel } from '~/composition/fb-pixel.js'
 export default {
   name: 'Empty',
-
+  setup() {
+    sendMemberPageViewToFbPixel()
+  },
   errorCaptured(error, vm, info) {
     if (vm.$route.name === 'premium-slug') {
       this.$sendMembershipErrorLog({
@@ -43,21 +46,6 @@ export default {
   },
   mounted() {
     fireActivationEvent.bind(this)()
-  },
-  head() {
-    return {
-      script: [
-        this.isLoggedIn
-          ? {
-              hid: 'facebookPixelMemberPageView',
-              innerHTML: `fbq('trackCustom', 'memberPageView');`,
-            }
-          : {},
-      ],
-      __dangerouslyDisableSanitizersByTagID: {
-        facebookPixelMemberPageView: ['innerHTML'],
-      },
-    }
   },
 }
 </script>

--- a/layouts/premium.vue
+++ b/layouts/premium.vue
@@ -37,12 +37,12 @@ import UiFooter from '~/components/UiFooter.vue'
 import TheGdpr from '~/components/TheGdpr.vue'
 
 import { fireActivationEvent } from '~/utils/google-optimize.js'
-import { sendMemberPageViewToFbPixel } from '~/composition/fb-pixel.js'
+import { useMemberPageViewToFbPixel } from '~/composition/fb-pixel.js'
 
 export default {
   name: 'Premium',
   setup() {
-    sendMemberPageViewToFbPixel()
+    useMemberPageViewToFbPixel()
   },
   components: {
     ContainerHeaderSectionMember,

--- a/layouts/premium.vue
+++ b/layouts/premium.vue
@@ -37,10 +37,13 @@ import UiFooter from '~/components/UiFooter.vue'
 import TheGdpr from '~/components/TheGdpr.vue'
 
 import { fireActivationEvent } from '~/utils/google-optimize.js'
+import { sendMemberPageViewToFbPixel } from '~/composition/fb-pixel.js'
 
 export default {
   name: 'Premium',
-
+  setup() {
+    sendMemberPageViewToFbPixel()
+  },
   components: {
     ContainerHeaderSectionMember,
     UiArticleIndex,
@@ -66,21 +69,6 @@ export default {
     handleIndexActive(isActive) {
       this.isIndexActive = isActive
     },
-  },
-  head() {
-    return {
-      script: [
-        this.isLoggedIn
-          ? {
-              hid: 'facebookPixelMemberPageView',
-              innerHTML: `fbq('trackCustom', 'memberPageView');`,
-            }
-          : {},
-      ],
-      __dangerouslyDisableSanitizersByTagID: {
-        facebookPixelMemberPageView: ['innerHTML'],
-      },
-    }
   },
 }
 </script>

--- a/layouts/premium.vue
+++ b/layouts/premium.vue
@@ -53,7 +53,11 @@ export default {
       isIndexActive: false,
     }
   },
-
+  computed: {
+    isLoggedIn() {
+      return this.$store.getters['membership/isLoggedIn']
+    },
+  },
   mounted() {
     fireActivationEvent.bind(this)()
   },
@@ -62,6 +66,21 @@ export default {
     handleIndexActive(isActive) {
       this.isIndexActive = isActive
     },
+  },
+  head() {
+    return {
+      script: [
+        this.isLoggedIn
+          ? {
+              hid: 'facebookPixelMemberPageView',
+              innerHTML: `fbq('trackCustom', 'memberPageView');`,
+            }
+          : {},
+      ],
+      __dangerouslyDisableSanitizersByTagID: {
+        facebookPixelMemberPageView: ['innerHTML'],
+      },
+    }
   },
 }
 </script>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -171,7 +171,7 @@ module.exports = {
 
             // Facebook Pixel
             {
-              hid: 'likrNotification',
+              hid: 'facebookPixel',
               innerHTML: `!function(f,b,e,v,n,t,s)
                 {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
                 n.callMethod.apply(n,arguments):n.queue.push(arguments)};
@@ -220,6 +220,7 @@ module.exports = {
       alexaNoScript: ['innerHTML'],
       comScore: ['innerHTML'],
       comScoreNoScript: ['innerHTML'],
+      facebookPixel: ['innerHTML'],
     },
   },
 

--- a/pages/subscribe/success.vue
+++ b/pages/subscribe/success.vue
@@ -34,14 +34,14 @@
           <a
             v-if="isNavigateFromPremiumPage"
             href="/section/member"
-            @click.once="sendCustomEventToFbPixel('back-to-Premium-page')"
+            @click.once="useCustomEventToFbPixel('back-to-Premium-page')"
           >
             <UiSubscribeButton title="瀏覽 Premium 會員文章" />
           </a>
           <a
             href="/profile/purchase"
             @click.once="
-              sendCustomEventToFbPixel('back-to-profile-purchase-page')
+              useCustomEventToFbPixel('back-to-profile-purchase-page')
             "
           >
             <UiMembershipButtonSecondary>
@@ -62,7 +62,7 @@ import SubscribeSuccessOrderInfoContentRow from '~/components/SubscribeSuccessOr
 import MembershipFormPerchaseInfo from '~/components/MembershipFormPerchaseInfo.vue'
 import UiSubscribeButton from '~/components/UiSubscribeButton.vue'
 import UiMembershipButtonSecondary from '~/components/UiMembershipButtonSecondary.vue'
-import { sendCustomEventToFbPixel } from '~/composition/fb-pixel.js'
+import { useCustomEventToFbPixel } from '~/composition/fb-pixel.js'
 export default {
   middleware: ['handle-go-to-marketing'],
   setup() {
@@ -74,7 +74,7 @@ export default {
       isNavigateFromPremiumPage: !!state?.value?.matches(
         '會員訂閱功能.方案購買流程.付款成功頁.是從會員文章頁來的'
       ),
-      sendCustomEventToFbPixel,
+      useCustomEventToFbPixel,
     }
   },
   components: {

--- a/pages/subscribe/success.vue
+++ b/pages/subscribe/success.vue
@@ -145,13 +145,6 @@ export default {
     },
   },
   methods: {
-    test() {
-      console.log('trigger')
-    },
-    sendFbPixelEvent(customEventName) {
-      window.fbq('trackCustom', customEventName)
-    },
-
     // TODO: remove due to not use anymore
     toggleHasLink() {
       this.hasLink = !this.hasLink

--- a/pages/subscribe/success.vue
+++ b/pages/subscribe/success.vue
@@ -34,13 +34,15 @@
           <a
             v-if="isNavigateFromPremiumPage"
             href="/section/member"
-            @click="sendFbPixelEvent('back-to-Premium-page')"
+            @click.once="sendCustomEventToFbPixel('back-to-Premium-page')"
           >
             <UiSubscribeButton title="瀏覽 Premium 會員文章" />
           </a>
           <a
             href="/profile/purchase"
-            @click="sendFbPixelEvent('back-to-profile-purchase-page')"
+            @click.once="
+              sendCustomEventToFbPixel('back-to-profile-purchase-page')
+            "
           >
             <UiMembershipButtonSecondary>
               <p v-if="isNavigateFromPremiumPage">回訂閱紀錄</p>
@@ -60,7 +62,7 @@ import SubscribeSuccessOrderInfoContentRow from '~/components/SubscribeSuccessOr
 import MembershipFormPerchaseInfo from '~/components/MembershipFormPerchaseInfo.vue'
 import UiSubscribeButton from '~/components/UiSubscribeButton.vue'
 import UiMembershipButtonSecondary from '~/components/UiMembershipButtonSecondary.vue'
-
+import { sendCustomEventToFbPixel } from '~/composition/fb-pixel.js'
 export default {
   middleware: ['handle-go-to-marketing'],
   setup() {
@@ -72,6 +74,7 @@ export default {
       isNavigateFromPremiumPage: !!state?.value?.matches(
         '會員訂閱功能.方案購買流程.付款成功頁.是從會員文章頁來的'
       ),
+      sendCustomEventToFbPixel,
     }
   },
   components: {
@@ -142,6 +145,9 @@ export default {
     },
   },
   methods: {
+    test() {
+      console.log('trigger')
+    },
     sendFbPixelEvent(customEventName) {
       window.fbq('trackCustom', customEventName)
     },

--- a/pages/subscribe/success.vue
+++ b/pages/subscribe/success.vue
@@ -31,10 +31,17 @@
           </div>
         </div>
         <div class="subscribe-success__info_button">
-          <a v-if="isNavigateFromPremiumPage" href="/section/member">
+          <a
+            v-if="isNavigateFromPremiumPage"
+            href="/section/member"
+            @click="sendFbPixelEvent('back-to-Premium-page')"
+          >
             <UiSubscribeButton title="瀏覽 Premium 會員文章" />
           </a>
-          <a href="/profile/purchase">
+          <a
+            href="/profile/purchase"
+            @click="sendFbPixelEvent('back-to-profile-purchase-page')"
+          >
             <UiMembershipButtonSecondary>
               <p v-if="isNavigateFromPremiumPage">回訂閱紀錄</p>
               <p v-else>回訂閱紀錄看購買文章</p>
@@ -135,6 +142,10 @@ export default {
     },
   },
   methods: {
+    sendFbPixelEvent(customEventName) {
+      window.fbq('trackCustom', customEventName)
+    },
+
     // TODO: remove due to not use anymore
     toggleHasLink() {
       this.hasLink = !this.hasLink


### PR DESCRIPTION
### 需求
1. 將nuxt.config.js中，針對script中的[`facebookPixel`](https://github.com/mirror-media/mirror-media-nuxt/pull/549/commits/5c1f7fcea41c8bbab79e4415ef10c8d624ac66a7#diff-65d5d69bb59dcc81ad971719549cdee5018f0a240add8b7ef5c65bee3e73dae0R223)，寫入`__dangerouslyDisableSanitizersByTagID`，使其可以正常執行，以追蹤所有使用者在全站的page view。
2.  為進一步追蹤「會員」在全站的page view，在三種layout（[`empty`](https://github.com/mirror-media/mirror-media-nuxt/pull/549/commits/5c1f7fcea41c8bbab79e4415ef10c8d624ac66a7#diff-547337e5e19d9d40681a9ebfae905cb905869088cb19074ef0a75b761d909e22R47-R61), [`premium`](https://github.com/mirror-media/mirror-media-nuxt/pull/549/commits/5c1f7fcea41c8bbab79e4415ef10c8d624ac66a7#diff-c20c53809a8fa777f903eaf4e6c2c7f53a11fe5e0b053adcb12d9367278cc619R70-R84), [`default`](https://github.com/mirror-media/mirror-media-nuxt/pull/549/commits/5c1f7fcea41c8bbab79e4415ef10c8d624ac66a7#diff-433a9abd4ca70520f69fc064c160bb093918ce26dda6087a8bbfdbe2895d1944R83-R97)）的head中埋入自訂的函式，皆為追蹤會員的pageview，且只有使用者為會員時，才會埋入並觸發該函式。
3. 在特定按鈕中fb pixel，當點擊按鈕時即觸發函式。

### 需要code review的部分
為需求的2. （埋入自訂函式）：

目前的做法為「在每個layout中，依據特定條件埋入一個相同的自訂函式」，雖然仍可達到全站埋入同一函式的效果，但就後續維護的角度而言，似乎有點冗？因為如果後續要修改，需要修改三個layout的程式碼。

有查過其他方法，如直接在nuxt.config.js中埋入，但因為nuxt.config.js中無法取得context，所以無法依據特定條件埋入函式。

想請問有無其他方法，為可以取得context作為條件判斷，又能夠在全站埋入函式，而不用再多個layout中埋程式碼？
