### PR TITLE
refactor(header): move css stylesheet to component UiSubscribeMagazin…

### DIFF
--- a/components/ContainerHeaderPremium.vue
+++ b/components/ContainerHeaderPremium.vue
@@ -444,54 +444,12 @@ header {
   flex-shrink: 0;
   align-items: center;
   z-index: 529;
-  &__and-magazine::v-deep {
+  &__and-magazine {
     display: flex;
     align-items: center;
     flex-direction: row-reverse;
     @include media-breakpoint-up(xl) {
       flex-direction: row;
-    }
-
-    .subscribe-magazine-entrance {
-      background: #000000;
-      color: #fff;
-
-      @include media-breakpoint-up(xl) {
-        display: block;
-      }
-    }
-
-    .field {
-      background-color: #d8d8d8;
-      top: 76px;
-      padding: 16px 24px;
-      &::after {
-        content: '';
-        display: block;
-        width: 0;
-        height: 0;
-        border-style: solid;
-        border-width: 0 8px 16px 8px;
-        border-color: transparent transparent #d8d8d8 transparent;
-        position: absolute;
-        top: -16px;
-        right: calc(5vw);
-        @include media-breakpoint-up(md) {
-          right: calc(5vw + 20px);
-        }
-      }
-
-      .search-bar-select {
-        height: 32px;
-      }
-
-      .search-bar-input {
-        height: 32px;
-        margin-top: 16px;
-        input {
-          border-radius: 8px;
-        }
-      }
     }
   }
 }

--- a/components/UiSubscribeMagazineEntrance.vue
+++ b/components/UiSubscribeMagazineEntrance.vue
@@ -1,11 +1,22 @@
 <template>
-  <div class="subscribe-magazine-entrance" @click="handleClick">
+  <div
+    :class="[
+      'subscribe-magazine-entrance',
+      { 'subscribe-magazine-entrance--black-background': isPremiumMember },
+    ]"
+    @click="handleClick"
+  >
     訂閱<br class="subscribe-magazine-entrance__br" />紙本雜誌
   </div>
 </template>
 
 <script>
 export default {
+  computed: {
+    isPremiumMember() {
+      return this.$store?.getters?.['membership-subscribe/isPremiumMember']
+    },
+  },
   methods: {
     handleClick() {
       this.$router.push('/papermag')
@@ -40,5 +51,9 @@ export default {
       display: none;
     }
   }
+}
+.subscribe-magazine-entrance--black-background {
+  background: #000000;
+  color: #fff;
 }
 </style>


### PR DESCRIPTION
…eEntrance

### 目前改動
將原位於`ContainerPremiumHeader.vue`並透過::v-deep導入的css 設定[.subscribe-magazine-entrance](.subscribe-magazine-entrance)，遷移至元件`UiSubscribeMagazineEntrance.vue`，並由computed variable `isPremium`控制顯示不同顏色。

### 改動原因
雖然v-deep好用是好用，但是因為是由父元件控制子元件的css，日後維護或改動時，無法直接從子元件看到使用的css為何。且子元件受父元件控制，程式碼耦合性高，若要需子元件從父元件分離，仍需花時間將程式碼從父元件抽出來。
我自己是覺得，除非是無法直接控制css的子元件（比如說第三方插入的圖片？），不然都可以直接由子元件自行控制css，
但這是我的看法，不知道大家的想法為何？
