### PR TITLE
chore: update cloudbuild.yaml. Stop copying config.js from Google Source Repository

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -24,12 +24,6 @@ steps:
       - ./gcskeyfile.json
   - name: bash
     args:
-      - cp
-      - "-R"
-      - ./configs.build/mirror-media/mirror-media-nuxt/${BRANCH_NAME}/config.js
-      - ./configs/config.js
-  - name: bash
-    args:
       - rm
       - "-R"
       - ./configs.build

--- a/configs/config.js
+++ b/configs/config.js
@@ -1,5 +1,5 @@
 export const API_PROTOCOL = process.env.API_PROTOCOL || 'http'
-export const API_HOST = process.env.API_HOST || '104.199.190.189'
+export const API_HOST = process.env.API_HOST || 'localhost'
 export const API_PORT = process.env.API_PORT || '8080'
 export const API_HOST_MEMBERSHIP_GATEWAY =
   process.env.API_HOST_MEMBERSHIP_GATEWAY || 'app-dev.mirrormedia.mg'


### PR DESCRIPTION
### PR 描述
因為 `configs/config.js` 檔案已經被 commit 進到 repo 中，`config.js` 的值都改從環境變數傳入。
此 PR 從 cloudbuild.yaml 中移除了「從 Google Source Repository 複製 config.js」的步驟。
`config.js` 的值皆由部署時，透過 k8s 傳入。相關 PR 請見 https://github.com/mirror-media/kubernetes-configs/pull/92 。

### 後續影響
既然 build 的過程沒有「從 Google Source Repository 複製 config.js」，那我們 Google Source Repository 上 `configs > mirror-media > mirror-media-nuxt > (dev|staging|prod) > config.js` 就不再維護了。
之後相關設定更動請到 [mirror-media/kubernetes-configs repo](https://github.com/mirror-media/kubernetes-configs/)。
