### PR TITLE
refactor(videohub): use same component UiYoutubeSubscribe whether is …

### DIFF
--- a/components/UiVideoSubscriptions.vue
+++ b/components/UiVideoSubscriptions.vue
@@ -3,20 +3,10 @@
     class="video-subscriptions"
     :class="{ isPremiumMember: isPremiumMember }"
   >
-    <div v-if="isPremiumMember" class="scroll-container premium">
-      <UiYoutubeSubscribeForPremium
-        v-for="channel in CHANNELS"
-        :key="`channel-${channel.id}`"
-        :channelId="channel.id"
-        :channelName="channel.name"
-        :channelTitle="channel.title"
-        class="video-subscriptions__channel"
-      />
-    </div>
-    <div v-else class="scroll-container">
+    <div class="scroll-container">
       <UiYoutubeSubscribe
         v-for="channel in CHANNELS"
-        :key="`channel-${channel}`"
+        :key="`channel-${channel.id}`"
         :channelId="channel.id"
         :channelName="channel.name"
         :channelTitle="channel.title"
@@ -28,7 +18,6 @@
 
 <script>
 import UiYoutubeSubscribe from './UiYoutubeSubscribe.vue'
-import UiYoutubeSubscribeForPremium from './UiYoutubeSubscribeForPremium.vue'
 
 const CHANNELS = [
   {
@@ -70,7 +59,6 @@ export default {
   title: 'UiVideoSubscriptions',
   components: {
     UiYoutubeSubscribe,
-    UiYoutubeSubscribeForPremium,
   },
   data() {
     return {

--- a/components/UiYoutubeSubscribe.vue
+++ b/components/UiYoutubeSubscribe.vue
@@ -6,12 +6,7 @@
         <div class="youtube-subscribe__name" @click="openChannel">
           {{ channelTitle }}
         </div>
-        <div
-          :data-channelid="channelId"
-          class="g-ytsubscribe"
-          data-layout="default"
-          data-count="hidden"
-        />
+        <div class="youtube-subscribe__btn" @click="handleClickBtn">訂閱</div>
       </section>
     </div>
   </LazyRenderer>
@@ -19,7 +14,7 @@
 
 <script>
 export default {
-  name: 'UiYoutubeSubscribe',
+  name: 'UiYoutubeSubscribeForPremium',
   props: {
     channelName: {
       type: String,
@@ -41,20 +36,6 @@ export default {
     },
   },
   methods: {
-    init() {
-      const hasInjectedSDK =
-        window.gapi || document.querySelector('#js-yt-platform')
-      if (!hasInjectedSDK) {
-        const youtubePlatformScript = document.createElement('script')
-        youtubePlatformScript.setAttribute('id', 'js-yt-platform')
-        youtubePlatformScript.setAttribute('defer', 'true')
-        youtubePlatformScript.setAttribute(
-          'src',
-          'https://apis.google.com/js/platform.js'
-        )
-        document.head.appendChild(youtubePlatformScript)
-      }
-    },
     handleClickBtn() {
       window.open(
         `https://www.youtube.com/channel/${this.channelId}?sub_confirmation=1`,
@@ -71,7 +52,7 @@ export default {
 <style lang="scss" scoped>
 .youtube-subscribe {
   display: flex;
-  width: 150px;
+  width: 105px;
 
   *:hover {
     cursor: pointer;
@@ -107,7 +88,3 @@ export default {
   }
 }
 </style>
-
-<!--
-  Document: https://developers.google.com/youtube/youtube_subscribe_button
--->

--- a/components/__tests__/UiYoutubeSubscribe.spec.js
+++ b/components/__tests__/UiYoutubeSubscribe.spec.js
@@ -1,4 +1,4 @@
-import UiYoutubeSubscribe from '../UiYoutubeSubscribe.vue'
+import UiYoutubeSubscribe from '../../deprecated/topic-page/components/UiYoutubeSubscribe.vue'
 import createWrapperHelper from '~/test/helpers/createWrapperHelper'
 
 const channelId = 'UCYkldEK001GxR884OZMFnRw'

--- a/deprecated/topic-page/components/UiYoutubeSubscribe.vue
+++ b/deprecated/topic-page/components/UiYoutubeSubscribe.vue
@@ -6,7 +6,12 @@
         <div class="youtube-subscribe__name" @click="openChannel">
           {{ channelTitle }}
         </div>
-        <div class="youtube-subscribe__btn" @click="handleClickBtn">訂閱</div>
+        <div
+          :data-channelid="channelId"
+          class="g-ytsubscribe"
+          data-layout="default"
+          data-count="hidden"
+        />
       </section>
     </div>
   </LazyRenderer>
@@ -14,7 +19,7 @@
 
 <script>
 export default {
-  name: 'UiYoutubeSubscribeForPremium',
+  name: 'UiYoutubeSubscribe',
   props: {
     channelName: {
       type: String,
@@ -36,6 +41,20 @@ export default {
     },
   },
   methods: {
+    init() {
+      const hasInjectedSDK =
+        window.gapi || document.querySelector('#js-yt-platform')
+      if (!hasInjectedSDK) {
+        const youtubePlatformScript = document.createElement('script')
+        youtubePlatformScript.setAttribute('id', 'js-yt-platform')
+        youtubePlatformScript.setAttribute('defer', 'true')
+        youtubePlatformScript.setAttribute(
+          'src',
+          'https://apis.google.com/js/platform.js'
+        )
+        document.head.appendChild(youtubePlatformScript)
+      }
+    },
     handleClickBtn() {
       window.open(
         `https://www.youtube.com/channel/${this.channelId}?sub_confirmation=1`,
@@ -52,7 +71,7 @@ export default {
 <style lang="scss" scoped>
 .youtube-subscribe {
   display: flex;
-  width: 105px;
+  width: 150px;
 
   *:hover {
     cursor: pointer;
@@ -88,3 +107,7 @@ export default {
   }
 }
 </style>
+
+<!--
+  Document: https://developers.google.com/youtube/youtube_subscribe_button
+-->


### PR DESCRIPTION
…premium member

原本元件有`UiVideoSubscriptions.vue`與`UiVideoSubscriptionsForPremium.vue`，使用哪個元件取決於是否為premium member，但因為後來決定無廣告版與有廣告版都使用同樣的UI，所以將既有的`UiVideoSubscriptions.vue`移至`deprecated/topic-page/components/UiYoutubeSubscribe.vue`，既有的`UiVideoSubscriptionsForPremium.vue`則更名為`UiVideoSubscriptions`。

但上述改動會影響到測試，影響到的測試檔為`components/__tests__/UiVideoSubscriptions.spec.js`（測試`UiVideoSubscriptions.vue`有沒有render出5個`UiVideoSubscriptions.vue`）與`components/__tests__/UiYoutubeSubscribe.spec.js`（測試該元件的屬性是否符合預期），但如果既有的元件已被棄用，那測試未來應有三個方向做改動：
1. 直接把測試檔刪掉
2. 讓被棄用的元件一直留在deprecated資料夾，測試檔也是以被棄用的元件作為測試單位
3. 改動既有的測試，讓測試單位符合預期
目前是2.的做法，但未來有時間的話，會朝3.去做。目前先開一個issue放需要新增/重構測試的list。