### PR TITLE
chore: pass ENV environment variable while nuxt build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ CMD [ "yarn", "start" ]
 
 COPY . .
 
+ARG ENV
+ENV ENV ${ENV}
 RUN yarn build \
     && apk add --no-cache ca-certificates \
     && apk del .build-deps

--- a/api/membership-proxy-v1.js
+++ b/api/membership-proxy-v1.js
@@ -5,8 +5,6 @@ const {
 } = require('../configs/config')
 const { createProxy } = require('./helpers')
 
-console.log('API_HOST_MEMBERSHIP_GATEWAY: ', API_HOST_MEMBERSHIP_GATEWAY)
-
 module.exports = createProxy(
   `${API_PROTOCOL}://${API_HOST_MEMBERSHIP_GATEWAY}:${API_PORT_MEMBERSHIP_GATEWAY}/api/v1`
 )

--- a/api/membership-proxy.js
+++ b/api/membership-proxy.js
@@ -5,8 +5,6 @@ const {
 } = require('../configs/config')
 const { createProxy } = require('./helpers')
 
-console.log('API_HOST_MEMBERSHIP_GATEWAY: ', API_HOST_MEMBERSHIP_GATEWAY)
-
 module.exports = createProxy(
   `${API_PROTOCOL}://${API_HOST_MEMBERSHIP_GATEWAY}:${API_PORT_MEMBERSHIP_GATEWAY}/api/v0`,
   3000

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -41,6 +41,8 @@ steps:
       - "gcr.io/$PROJECT_ID/mirror-media-nuxt:${BRANCH_NAME}_${SHORT_SHA}_${BUILD_ID}"
       - "--cache-from"
       - "gcr.io/$PROJECT_ID/mirror-media-nuxt:${BRANCH_NAME}"
+      - "--build-arg"
+      - "ENV=${BRANCH_NAME}"
       - .
   - name: gcr.io/cloud-builders/docker
     args:

--- a/configs/config.js
+++ b/configs/config.js
@@ -1,3 +1,18 @@
+const ENV = process.env.ENV || 'local'
+
+let GOOGLE_OPT_CONTAINER_ID = '' // eslint-disable-line
+switch (ENV) {
+  case 'prod':
+  case 'staging':
+    GOOGLE_OPT_CONTAINER_ID = 'OPT-N9L3WX3'
+    break
+  case 'dev':
+  default:
+    GOOGLE_OPT_CONTAINER_ID = 'OPT-NHZNB2Z'
+}
+
+export { ENV, GOOGLE_OPT_CONTAINER_ID }
+
 export const API_PROTOCOL = process.env.API_PROTOCOL || 'http'
 export const API_HOST = process.env.API_HOST || 'localhost'
 export const API_PORT = process.env.API_PORT || '8080'
@@ -9,9 +24,8 @@ export const API_PORT_MEMBERSHIP_GATEWAY =
   process.env.API_PORT_MEMBERSHIP_GATEWAY || '80'
 export const API_TIMEOUT = process.env.API_TIMEOUT || 5000
 export const SALEOR_HOST = process.env.SALEOR_HOST || '104.155.209.114'
-export const API_PATH_FRONTEND = process.env.API_PATH_FRONTEND || 'api/v2'
+export const API_PATH_FRONTEND = 'api/v2'
 export const DOMAIN_NAME = process.env.DOMAIN_NAME || 'www.mirrormedia.mg'
-export const ENV = process.env.ENV || 'local'
 export const IS_AD_DISABLE = process.env.IS_AD_DISABLE === 'true' || false
 export const GPT_MODE = process.env.GPT_MODE || 'dev'
 export const PREVIEW_QUERY = process.env.PREVIEW_QUERY || 'preview=true'
@@ -28,8 +42,6 @@ export const GCP_PROJECT_ID =
 export const GCP_STACKDRIVER_LOG_NAME =
   process.env.GCP_STACKDRIVER_LOG_NAME || 'mirror-media-nuxt-user-behavior'
 export const GCP_KEYFILE = process.env.GCP_KEYFILE || './gcskeyfile.json'
-export const GOOGLE_OPT_CONTAINER_ID =
-  process.env.GOOGLE_OPT_CONTAINER_ID || 'OPT-NHZNB2Z'
 export const API_MEMBER_SUBSCRIPTION_GATEWAY =
   process.env.API_MEMBER_SUBSCRIPTION_GATEWAY ||
   'app-dev.mirrormedia.mg/api/v2/graphql/member'


### PR DESCRIPTION
### 問題描述
目前在[www-staging.mirrormedia.mg](http://www-staging.mirrormedia.mg/) 登入會員會失敗。
原因是 [www-staging.mirrormedia.mg](http://www-staging.mirrormedia.mg/) 使用了 [mirrormediaapptest firebase project](https://console.firebase.google.com/u/0/project/mirrormediaapptest/settings/general/android:com.mirrormedia.news.dev)（這是我們 dev 環境用的 firebase project）。
正常來說 staging mirror-media-nuxt 是要採用 [mirrormedia-staging firebase project](https://console.firebase.google.com/u/0/project/mirrormedia-staging/settings/general/web:OGU5ZjAxZGEtMGMxMS00OWQ2LWE5ZTktZTFiMTExZDNhNzJk) 才對。
請見附圖。

![Screen Shot 2022-04-06 at 6 23 29 PM](https://user-images.githubusercontent.com/3000343/162006728-f425ed1b-28a8-48fb-a53a-0acf442185e4.png)


### 解決辦法
`yarn build` 時會執行 `nuxt build`，而 `nuxt build` 會透過 `nuxt.config.js` 來產生 server 和 client 的 static files。但因為 `nuxt.config.js` 使用了 `configs/config.js` 裡的 `ENV` 變數 （見 [source code](https://github.com/mirror-media/mirror-media-nuxt/blob/dev/nuxt.config.js#L10-L14)），所以在 `yarn build` 時，我們得透過 cloudbuild.yaml 傳送 `ENV` 環境變數至 Dockerfile，讓 `yarn build` 能根據不同的環境產生不同的 server/client static files。

### 其他變動
- 因 `API_PATH_FRONTEND` 和 `GOOGLE_OPT_CONTAINER_ID` 非機密資訊，因此，不透過環境變數傳值給`API_PATH_FRONTEND` 和 `GOOGLE_OPT_CONTAINER_ID`

### Related PR
https://github.com/mirror-media/kubernetes-configs/pull/96