### PR TITLE
fix(pre/story): problem of showing wrong header in photography

### DIFF
--- a/pages/pre/story/_slug.vue
+++ b/pages/pre/story/_slug.vue
@@ -1,111 +1,118 @@
 <template>
   <section>
-    <UiLanding
-      class="landing"
-      :sectionLabel="post.sectionLabelFirst"
-      :sectionLabelColor="post.sectionLabelFirstColor"
-      :sectionLabelHref="`/section/${post.sectionFirstName}`"
-      :title="post.title"
-      :titleStyle="{
-        fontFamily: 'sans-serif',
-        fontWeight: 'normal',
-      }"
-      :coverVideo="post.coverVideo"
-      :coverPicture="post.coverPicture"
-      :heroCaption="post.heroCaption"
-    />
-    <UiArticleInfo
-      class="article-info"
-      :publishTime="post.publishedDate"
-      :updateTime="post.updatedAt"
-      :writers="post.writers"
-      :extendByline="post.extendByline"
-      :photographers="post.photographers"
-      :tags="post.tags"
-      @shareLinksVisibilityChanged="handleShareLinksVisibilityChanged"
-    />
-    <div class="article-body-wrapper">
-      <UiArticleBody
-        ref="articleBody"
-        class="culture-post__article-body"
-        :postId="post.id"
-        :brief="post.brief"
-        :briefColor="post.sectionLabelFirstColor"
-        :content="post.content"
-        :isArticleContentTruncatedByGateway="post.isTruncated"
-        :isLoading="false"
-        :isFail="false"
-        :failTimes="0"
-        :hideInvite="true"
-        @reload="handleReload"
+    <section v-if="isStylePhotography">
+      <ContainerPhotoGallery :story="story" />
+    </section>
+    <section v-else>
+      <ContainerHeaderPremium />
+
+      <UiLanding
+        class="landing"
+        :sectionLabel="post.sectionLabelFirst"
+        :sectionLabelColor="post.sectionLabelFirstColor"
+        :sectionLabelHref="`/section/${post.sectionFirstName}`"
+        :title="post.title"
+        :titleStyle="{
+          fontFamily: 'sans-serif',
+          fontWeight: 'normal',
+        }"
+        :coverVideo="post.coverVideo"
+        :coverPicture="post.coverPicture"
+        :heroCaption="post.heroCaption"
       />
-      <transition name="fade">
-        <UiShareLinksHasCopyLink
-          v-show="showShareLinksAside"
-          class="article-body-wrapper__share-links"
-          :direction="'vertical-reverse'"
+      <UiArticleInfo
+        class="article-info"
+        :publishTime="post.publishedDate"
+        :updateTime="post.updatedAt"
+        :writers="post.writers"
+        :extendByline="post.extendByline"
+        :photographers="post.photographers"
+        :tags="post.tags"
+        @shareLinksVisibilityChanged="handleShareLinksVisibilityChanged"
+      />
+      <div class="article-body-wrapper">
+        <UiArticleBody
+          ref="articleBody"
+          class="culture-post__article-body"
+          :postId="post.id"
+          :brief="post.brief"
+          :briefColor="post.sectionLabelFirstColor"
+          :content="post.content"
+          :isArticleContentTruncatedByGateway="post.isTruncated"
+          :isLoading="false"
+          :isFail="false"
+          :failTimes="0"
+          :hideInvite="true"
+          @reload="handleReload"
         />
-      </transition>
-    </div>
-    <div class="additional-info-wrapper">
-      <UiAnniversary class="anniversary" />
-      <UiSocialNetworkServices class="sns" />
-    </div>
-    <LazyRenderer
-      class="story__list related-list"
-      @load="handleLoadStoryListRelated"
-    >
-      <UiStoryListRelatedMobileLayoutColumn
-        :items="relateds"
-        :images="relatedImages"
-        @sendGa="sendGaForClick('related')"
-      >
-        <!--        <template v-if="canAdvertise" #ads>-->
-        <!--          <ClientOnly>-->
-        <!--            <MicroAdWithLabel-->
-        <!--              v-for="unit in microAdUnits[device]"-->
-        <!--              :key="unit.name"-->
-        <!--              :unitId="unit.id"-->
-        <!--            />-->
-        <!--            <div id="_popIn_recommend"></div>-->
-        <!--          </ClientOnly>-->
-        <!--        </template>-->
-      </UiStoryListRelatedMobileLayoutColumn>
-    </LazyRenderer>
-    <section
-      v-observe-visibility="handleLatestListVisibilityChanged"
-      class="latest-list-wrapper"
-    >
-      <h1 class="latest-list-wrapper__title">最新文章</h1>
-      <LazyRenderer
-        class="latest-list-wrapper__latest-list"
-        @load="fetchLatestStories"
-      >
-        <section v-if="doesHaveLatestStories">
-          <UiArticleListCompact
-            :items="latestStories"
-            @sendGa="sendGaForClick('popular')"
+        <transition name="fade">
+          <UiShareLinksHasCopyLink
+            v-show="showShareLinksAside"
+            class="article-body-wrapper__share-links"
+            :direction="'vertical-reverse'"
           />
-        </section>
-      </LazyRenderer>
-    </section>
-    <div class="separator" />
-    <section class="popular-list-wrapper">
-      <h1 class="popular-list-wrapper__title">熱門文章</h1>
+        </transition>
+      </div>
+      <div class="additional-info-wrapper">
+        <UiAnniversary class="anniversary" />
+        <UiSocialNetworkServices class="sns" />
+      </div>
       <LazyRenderer
-        class="popular-list-wrapper__popular-list"
-        @load="fetchPopularStories"
+        class="story__list related-list"
+        @load="handleLoadStoryListRelated"
       >
-        <section v-if="doesHavePopularStories">
-          <UiArticleListCompact
-            :items="popularStories"
-            :titleColor="'#054f77'"
-            @sendGa="sendGaForClick('popular')"
-          />
-        </section>
+        <UiStoryListRelatedMobileLayoutColumn
+          :items="relateds"
+          :images="relatedImages"
+          @sendGa="sendGaForClick('related')"
+        >
+          <!--        <template v-if="canAdvertise" #ads>-->
+          <!--          <ClientOnly>-->
+          <!--            <MicroAdWithLabel-->
+          <!--              v-for="unit in microAdUnits[device]"-->
+          <!--              :key="unit.name"-->
+          <!--              :unitId="unit.id"-->
+          <!--            />-->
+          <!--            <div id="_popIn_recommend"></div>-->
+          <!--          </ClientOnly>-->
+          <!--        </template>-->
+        </UiStoryListRelatedMobileLayoutColumn>
       </LazyRenderer>
+      <section
+        v-observe-visibility="handleLatestListVisibilityChanged"
+        class="latest-list-wrapper"
+      >
+        <h1 class="latest-list-wrapper__title">最新文章</h1>
+        <LazyRenderer
+          class="latest-list-wrapper__latest-list"
+          @load="fetchLatestStories"
+        >
+          <section v-if="doesHaveLatestStories">
+            <UiArticleListCompact
+              :items="latestStories"
+              @sendGa="sendGaForClick('popular')"
+            />
+          </section>
+        </LazyRenderer>
+      </section>
+      <div class="separator" />
+      <section class="popular-list-wrapper">
+        <h1 class="popular-list-wrapper__title">熱門文章</h1>
+        <LazyRenderer
+          class="popular-list-wrapper__popular-list"
+          @load="fetchPopularStories"
+        >
+          <section v-if="doesHavePopularStories">
+            <UiArticleListCompact
+              :items="popularStories"
+              :titleColor="'#054f77'"
+              @sendGa="sendGaForClick('popular')"
+            />
+          </section>
+        </LazyRenderer>
+      </section>
+      <UiShareLinksToggled class="share-toggled" />
     </section>
-    <UiShareLinksToggled class="share-toggled" />
   </section>
 </template>
 
@@ -121,9 +128,8 @@ import UiStoryListRelatedMobileLayoutColumn from '~/components/UiStoryListRelate
 import UiArticleListCompact from '~/components/UiArticleListCompact.vue'
 import UiShareLinksToggled from '~/components/UiShareLinksToggled.vue'
 import UiShareLinksHasCopyLink from '~/components/UiShareLinksHasCopyLink.vue'
-
-// import MicroAdWithLabel from '~/components/MicroAdWithLabel.vue'
-
+import ContainerPhotoGallery from '~/components/photo-gallery/ContainerPhotoGallery.vue' // import MicroAdWithLabel from '~/components/MicroAdWithLabel.vue'
+import ContainerHeaderPremium from '~/components/ContainerHeaderPremium.vue'
 import { DOMAIN_NAME, ENV, PREVIEW_QUERY } from '~/configs/config'
 import { getSectionColor } from '~/utils/index.js'
 
@@ -147,9 +153,12 @@ export default {
     UiArticleListCompact,
     UiShareLinksToggled,
     UiShareLinksHasCopyLink,
+    ContainerPhotoGallery,
+    ContainerHeaderPremium,
 
     // MicroAdWithLabel,
   },
+  layout: 'empty',
   async fetch() {
     const processPostResponse = (response) => {
       if (response.status === 'fulfilled') {
@@ -158,7 +167,6 @@ export default {
           'setCanAdvertise',
           !this.story.hiddenAdvertised ?? true
         )
-
         const isTitleExist = this.story.title
         const isContentExist = (this.story?.content?.apiData ?? []).length > 0
         if (!isTitleExist || !isContentExist) {
@@ -346,7 +354,9 @@ export default {
     relateds() {
       return (this.story.relateds ?? []).filter((item) => item.slug)
     },
-
+    isStylePhotography() {
+      return this.story.style === 'photography'
+    },
     section() {
       return this.story.sections?.[0] || {}
     },


### PR DESCRIPTION
### Asana Task
https://app.asana.com/0/1202011362468166/1202038792798619/f
### Current Bug
在無廣告版中，若`/story`的文章樣式為photography，則會顯示錯誤的header與layout。可自行至測試機參閱該篇文章: /pre/story/20170924photo001

### Solution 
原本的寫法是在/pre/story皆使用`layout/default.vue`，並藉由會員狀態顯示不同的header。
現在則是將/pre/story的layout改用`empty.vue`，並判斷story的文章樣式是否為photography，如果是的話則顯示component [ContainerPhotoGallery](https://github.com/mirror-media/mirror-media-nuxt/pull/584/commits/cb1dcf97f5d25ace083b8517f7dd15f1093082ea#diff-d600d4cc0071713d424e854143a3bbc51f525cf7b7d2d88c573eec740ab34c3fR4)，不是的話則顯示Component       `ContainerHeaderPremium`與文章。
簡單來說，就是改成與/story/_slug.vue同樣的寫法。
