### PR TITLE
fix: slove the problem /pre/story page still cache

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -253,7 +253,6 @@ module.exports = {
    */
   serverMiddleware: [
     express.urlencoded({ extended: true }),
-    '~/api/headers.js',
     {
       path: `/${API_PATH_FRONTEND}/gcs`,
       handler: '~/api/gcs.js',
@@ -300,6 +299,7 @@ module.exports = {
       handler: '~/api/papermag.js',
     },
     { path: `/${API_PATH_FRONTEND}`, handler: '~/api/index.js' }, // this proxy MUST be in the last of serverMiddleware
+    '~/api/headers.js',
   ],
 
   /**


### PR DESCRIPTION
### 現況
1. 當使用者進入 `/story` 或 `/pre/story` 頁面時，會經過該頁面中的 `middleware` 判斷，如果非年月訂閱會員則導向前者，是則導向後者。
相關檔案：https://github.com/mirror-media/mirror-media-nuxt/blob/dev/middleware/handle-story-premium-redirect.js
2. 另外現在 cache 都存於 [/api/headers,.js](https://github.com/mirror-media/mirror-media-nuxt/blob/dev/api/headers.js) 中，若為 `/pre/story` 則不 cache。

### 問題
若在年月訂閱會員時進入 `/story` 頁面，被 middleware 導向 `/pre/story` 時，似乎不會重新經過 `/api/headers,.js` 檔案，因此依然會 cache，導致 brief 和下方延伸閱讀出現錯誤。

### 解法
將 `/api/headers,.js` 在 `/nuxt.config.js` 中 [servermiddleware](https://github.com/mirror-media/mirror-media-nuxt/blob/dev/nuxt.config.js#L254) 中的順序移到最後，似乎就可以解決這個問題了。

### 疑問
1. 這樣做會有什麼副作用嗎？
2. `/page` 中的 middleware 和 `servermiddleware` 的執行順序為何？為什麼移到最後就能解決該問題？