### PR TITLE
feat(package.json): remove @xstate/inspect

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@nuxtjs/gtm": "^2.4.0",
     "@nuxtjs/pwa": "^3.0.2",
     "@twreporter/errors": "^1.1.1",
-    "@xstate/inspect": "^0.4.1",
     "axios": "^0.21.0",
     "big-integer": "^1.6.48",
     "body-parser": "^1.19.0",


### PR DESCRIPTION
### 問題描述
起因是[會員訂閱 commit](https://github.com/mirror-media/mirror-media-nuxt/commit/71a24d9688a0a9dde4579a99b6026749b88df774)  branch 分支時凱文還在拔除 xstate ，因此不小心一起 merger 進來。搜尋後確認沒有其他地方會 impoet ` @xstate/inspect` ，因此只從 `package.json` 檔案中移除。