### PR TITLE
chore(package.json): assign node version to ~14.19.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build-storybook": "build-storybook"
   },
   "engines": {
-    "node": ">= 12"
+    "node": "~14.19.1"
   },
   "lint-staged": {
     "*.{js,vue}": "eslint --ext .js,.vue --ignore-path .gitignore"


### PR DESCRIPTION
原本package.json中，node指定的版本為`>=12`，但Dockerfile裡面已經升到14.19.1了，未避免開發出現未知的錯誤，故在package.json中指定node version 為`~14.19.1`。
未來有時間的話，會在將node升到v16。