### PR TITLE
feat(topic): add redesign topic list

### DIFF
--- a/deprecated/topic-page/Topic.vue
+++ b/deprecated/topic-page/Topic.vue
@@ -446,8 +446,11 @@ export default {
     await fetchData(this.$store, this.$route.params.topicId)
     await this.beforeRouteUpdate({ path: this.$route.path }, '', () => {})
     if (this.shouldRenderRedesignTopicList) {
-      await this.initList(true)
-      await this.initList(false)
+      const typeOfIsFeaturedArticles = [true, false]
+      await Promise.all(
+        typeOfIsFeaturedArticles.map((item) => this.fetchList(1, item))
+      )
+      this.concatArticleList()
     }
   },
   data() {
@@ -850,6 +853,20 @@ export default {
     window.removeEventListener('scroll', this.timelineScrollHandler)
   },
   methods: {
+    concatArticleList() {
+      if (this.articlesIsFeaturedCount < MAXRESULT) {
+        this.articlesIsFeatured = this.articlesIsFeatured?.concat(
+          _.take(
+            this.articlesIsNotFeatured,
+            MAXRESULT - this.articlesIsFeaturedCount
+          )
+        )
+        this.articlesIsNotFeatured = this.articlesIsNotFeatured?.slice(
+          MAXRESULT - this.articlesIsFeaturedCount,
+          MAXRESULT
+        )
+      }
+    },
     formatArticles(oldArticlesList, newArticlesList) {
       /*
        * three situation:
@@ -865,9 +882,7 @@ export default {
         return oldArticlesList
       }
     },
-    async initList(isFeatured = false) {
-      await this.fetchList(1, isFeatured)
-    },
+
     async fetchList(page, isFeatured = false) {
       const data = await this.$fetchPostsFromMembershipGateway({
         maxResults: MAXRESULT,

--- a/deprecated/topic-page/Topic.vue
+++ b/deprecated/topic-page/Topic.vue
@@ -99,6 +99,47 @@
             />
           </div>
         </template>
+        <ListBody
+          v-else-if="topicType === 'list'"
+          :mediaData="mediaData"
+          :isPresidentElectionId="isPresidentElectionId"
+          :candidateData="candidateData"
+          :loading="loading"
+          :leadingType="getValue(topic, ['leading'])"
+          @loadMorePresident="loadMorePresident"
+        >
+          <template v-slot:articleList>
+            <article-list
+              v-if="!isPresidentElectionId"
+              id="articleList"
+              ref="articleList"
+              :articles="autoScrollArticles"
+              :hasDFP="false"
+            />
+          </template>
+          <template v-slot:vueDfp
+            ><div v-if="hasDFP" class="ad">
+              <vue-dfp
+                :is="props.vueDfp"
+                :pos="dfpPos"
+                :dfpUnits="props.dfpUnits"
+                :section="props.section"
+                :dfpId="props.dfpId"
+                :unitId="mobileDfp"
+                :size="getValue($store, 'getters.deprecatedStore.adSize')"
+              /></div
+          ></template>
+          <template v-slot:articleListAutoScroll>
+            <article-list
+              v-if="!isPresidentElectionId"
+              v-show="hasAutoScroll"
+              id="articleListAutoScroll"
+              ref="articleListAutoScroll"
+              :articles="autoScrollArticlesLoadMore"
+              :hasDFP="false"
+            />
+          </template>
+        </ListBody>
 
         <template v-else>
           <div class="topic">
@@ -161,7 +202,6 @@ import Cookie from 'vue-cookie'
 import VueDfpProvider from 'plate-vue-dfp/DfpProvider.vue'
 import { currentYPosition, elmYPosition } from '../kc-scroll'
 import { adtracker } from './util/adtracking'
-
 import { currEnv, getTruncatedVal, getValue, unLockJS } from './util/comm'
 import { getRole } from './util/mmABRoleAssign'
 import {
@@ -197,6 +237,7 @@ import ArticleList from './components/ArticleList.vue'
 import ProjectSliderContainer from './components/project/ProjectSliderContainer.vue'
 // eslint-disable-next-line no-unused-vars
 import { createStore } from './store'
+import ListBody from './components/list/ListBody.vue'
 
 const MAXRESULT = 12
 const PAGE = 1
@@ -392,6 +433,7 @@ export default {
     ProjectSliderContainer,
     PresidentElectionProgress,
     PresidentElectionList,
+    ListBody,
   },
 
   /*
@@ -771,6 +813,10 @@ export default {
   },
   updated() {
     this.updateSysStage()
+    console.log(this.pageStyle)
+    console.log(this.topicType)
+    console.log(this.getValue)
+    console.log(this.$refs.articleList)
   },
   destroyed() {
     window.removeEventListener('resize', this.updateViewport)
@@ -778,6 +824,9 @@ export default {
     window.removeEventListener('scroll', this.timelineScrollHandler)
   },
   methods: {
+    testEmit(data1, data2) {
+      console.log(data2.$el.offsetHeight)
+    },
     checkIfLockJS() {
       unLockJS()
     },
@@ -859,6 +908,7 @@ export default {
         const articleListBottom =
           this.elmYPosition('#articleList') +
           this.$refs.articleList.$el.offsetHeight
+
         this.articleListAutoScrollHeight =
           this.$refs.articleListAutoScroll.$el.offsetHeight
         const articleListAutoScrollBottom =

--- a/deprecated/topic-page/components/list/ListBody.vue
+++ b/deprecated/topic-page/components/list/ListBody.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="topic-wrapper">
     <div class="topic">
       <div class="topic-title">
         <h1 />
@@ -13,12 +13,18 @@
       :candidateData="candidateData"
       @loadMore="loadMorePresident"
     />
-
-    <slot name="articleList"></slot>
-
-    <slot name="vueDfp"></slot>
-    <slot name="articleListAutoScroll"></slot>
-
+    <div class="article-list">
+      <slot name="articleListIsFeatured"></slot>
+      <button
+        v-if="shouldLoadMore"
+        class="load-more-button"
+        @click="loadMoreIsFeaturedArticles()"
+      >
+        看更多
+      </button>
+      <slot name="vueDfp"></slot>
+      <slot name="articlesIsNotFeatured"></slot>
+    </div>
     <Loading :show="loading" />
     <Share :right="`20px`" :bottom="`20px`" />
   </div>
@@ -41,6 +47,7 @@ export default {
     PresidentElectionList,
   },
   props: [
+    'shouldLoadMore',
     'mediaData',
     'isPresidentElectionId',
     'candidateData',
@@ -50,16 +57,36 @@ export default {
     'loading',
     'leadingType',
   ],
-
   destroyed() {},
   updated() {
     // console.log(this.$refs.articleList)
   },
-  methods: { getValue },
+  methods: {
+    getValue,
+    loadMoreIsFeaturedArticles() {
+      this.$emit('loadMoreIsFeaturedArticles')
+    },
+  },
 }
 </script>
 
 <style lang="stylus" scoped>
+.article-list
+  display flex
+  flex-direction column
+  align-items center
+  justify-content center
+.load-more-button
+  background #FFFFFF
+  border 1px solid rgba(0, 0, 0, 0.3)
+  border-radius: 2px
+  width 176px
+  height 48px
+  margin-top 20px
+  @media (min-width: 320px)
+    width 320px
+  @media (min-width: 600px)
+    margin 0 auto
 
 .topic
   position relative

--- a/deprecated/topic-page/components/list/ListBody.vue
+++ b/deprecated/topic-page/components/list/ListBody.vue
@@ -1,0 +1,170 @@
+<template>
+  <div>
+    <div class="topic">
+      <div class="topic-title">
+        <h1 />
+      </div>
+      <leading v-if="leadingType" :type="leadingType" :mediaData="mediaData" />
+    </div>
+
+    <PresidentElectionProgress v-if="isPresidentElectionId" />
+    <PresidentElectionList
+      v-if="isPresidentElectionId"
+      :candidateData="candidateData"
+      @loadMore="loadMorePresident"
+    />
+
+    <slot name="articleList"></slot>
+
+    <slot name="vueDfp"></slot>
+    <slot name="articleListAutoScroll"></slot>
+
+    <Loading :show="loading" />
+    <Share :right="`20px`" :bottom="`20px`" />
+  </div>
+</template>
+<script>
+import PresidentElectionProgress from '../PresidentElectionProgress.vue'
+import PresidentElectionList from '../PresidentElectionList.vue'
+import { getValue } from '../../util/comm'
+import Leading from '../Leading.vue'
+import Loading from '../Loading.vue'
+import Share from '../Share.vue'
+
+export default {
+  components: {
+    leading: Leading,
+    Loading,
+    Share,
+
+    PresidentElectionProgress,
+    PresidentElectionList,
+  },
+  props: [
+    'mediaData',
+    'isPresidentElectionId',
+    'candidateData',
+    'autoScrollArticles',
+    'autoScrollArticlesLoadMore',
+    'scrollHandler',
+    'loading',
+    'leadingType',
+  ],
+
+  destroyed() {},
+  updated() {
+    // console.log(this.$refs.articleList)
+  },
+  methods: { getValue },
+}
+</script>
+
+<style lang="stylus" scoped>
+
+.topic
+  position relative
+  width 100%
+  padding-top 66.66%
+  background-color rgba(135, 156, 169, 0.15)
+  margin-bottom 20px
+  background-repeat no-repeat
+  background-position center center
+  background-size cover
+  &-view
+    background-color #f2f2f2
+  &-title
+    position absolute
+    top 50%
+    left 50%
+    transform translate(-50%, -50%)
+    width 80%
+    height 50%
+    background-size cover
+    background-repeat no-repeat
+    h1
+      margin 0
+
+.topic-view.portraitWall
+  .topic
+    margin 0
+
+.topicTimeline
+  &__logo
+    position fixed
+    z-index 999
+    top 5px
+    left 5px
+    width 40px
+    height 40px
+    > img
+      width 100%
+  &__projects
+    width 100%
+    padding 1em
+    background-color #4d4d4d
+    .project-container
+      margin 1em 0
+      background-color #fff
+      .proj_title
+        display none
+    > h1
+      margin 0
+      color #fff
+      text-align center
+      font-weight 200
+
+@media (min-width: 600px)
+  .topic-view.wide
+    .listArticleBlock
+      display flex
+      width 100%
+      margin 0 10px
+      & + .listArticleBlock
+        margin-top 40px
+        margin-bottom 0
+      &__figure
+        width 50%
+        padding-top 33.33%
+        &--colorBlock
+          display none
+      &__content
+        display flex
+        flex-direction column
+        align-items flex-start
+        width 50%
+        padding 40px 30px 30px
+        h2
+          min-height 0
+          padding 0
+          font-size 1.6rem
+          font-weight bold
+        p
+          margin-top 1em
+          font-size 1.2rem
+        &--colorBlock
+          display block
+          margin-bottom 1em
+          padding .5em
+          color #fff
+          letter-spacing 1px
+
+  .topicTimeline
+    &__projects
+      padding 5% 10%
+
+@media (min-width: 900px)
+  .topic
+    height 600px
+    padding-top 0
+    &-title
+      height 200px
+      width 400px
+      color #fff
+      background-size contain
+      background-position center center
+
+.ad-container
+  display flex
+  justify-content center
+  align-items center
+</style>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -597,6 +597,7 @@ module.exports = {
 
   publicRuntimeConfig: {
     noAdFeatureToggle: process.env.NO_AD_FEATURE_TOGGLE || 'off',
+    topicListFeatureToggle: process.env.TOPIC_LIST_FEATURE_TOGGLE || 'off',
   },
 
   env: {


### PR DESCRIPTION
[asana卡片](https://app.asana.com/0/1181156545719626/1202159652528715/f)

由於topic頁的程式碼較為久遠，所以在實作新功能時，先著手進行重構，再加入新功能。
原本打算是將整個topic頁重構，但考量到時間成本後，決定先重構一部分。
以下說明每個commit所實作的順序：
1. [bc5217e](https://github.com/mirror-media/mirror-media-nuxt/pull/625/commits/bc5217ef9217d2d19462febf50e991ee54cda2c8)：重構既有程式碼，並加入新元件`ListBody`。
   由於這次所要實作的功能，乃是topicType === 'list'的頁面。這邊先從既有的程式碼中，抽出要實作新功能的部分，並將其元件化成ListBody。
    而必須注意的是，articles乃是採用[`<template v-slot>`](https://github.com/mirror-media/mirror-media-nuxt/pull/625/commits/bc5217ef9217d2d19462febf50e991ee54cda2c8#diff-9316a1982ecac23af9c2a186560a7ccc751308f4cd0f4bd30b0abe664c6924aaR111-R118)的方式，將其插入元件的named slot，而非常用的props資料予元件：原因在於，topic頁觸發loadmore的方式，乃是在頁面加入eventLister，並觸發[`scrollHandler()`](https://github.com/mirror-media/mirror-media-nuxt/blob/bc5217ef9217d2d19462febf50e991ee54cda2c8/deprecated/topic-page/Topic.vue#L901)。若仔細觀察scrollHandler()的程式碼，他都是依據`this.$refs`去決定要不要觸發函式，但如果把資料都props進去的話，就抓不到`this.$refs`。當然更好的方式是不要用監聽+`this.$refs` (我覺得這是不太好的寫法，一直監聽scroll很耗效能)，而是採用我們常用的套件vue-infinite-loading，但為了避免大幅度重構導致程式碼整組壞掉，所以只好先採用既有的寫法。
此時都還沒有實作新功能。
2. [363a096](https://github.com/mirror-media/mirror-media-nuxt/pull/625/commits/363a0962eb45482acbe22daa3dbe0ae0ce70f29a)：實作新功能，並加入feature toggle。
    這個commit則是實作新功能，以前的topic頁是一次拿到不區分屬性的12筆文章，新功能會希望同時分別拿到置頂跟非置頂的文章。在程式碼中，置頂文章都會加入前綴`isFeatured`，非置頂文章則會加入`notFeatured`，已方便跟舊有功能所拿到的資料作區別。
   首先需要解決的是 **我要如何拿到置頂跟非置頂的文章** ，翻了一下舊的api，真的是找不到在query上可以設定isFeatured與否的api，又考量到topic頁原本都是舊的api（我也沒有全部看完，只覺得打的方式很繁瑣），終有一天要棄用，不如現在就直接改用新的api。所以直接改打[`$fetchPostsFromMembershipGateway`](https://github.com/mirror-media/mirror-media-nuxt/pull/625/commits/363a0962eb45482acbe22daa3dbe0ae0ce70f29a#diff-9316a1982ecac23af9c2a186560a7ccc751308f4cd0f4bd30b0abe664c6924aaR872)。
  這時可以拿到置頂跟非置頂的文章了，下一步我想先解決的是：**要如何讓非置頂的文章可以往下滑動時load more？** 這時要改兩個，一個是eventLister所觸發的[`scrollHandler()`](https://github.com/mirror-media/mirror-media-nuxt/pull/625/commits/363a0962eb45482acbe22daa3dbe0ae0ce70f29a#diff-9316a1982ecac23af9c2a186560a7ccc751308f4cd0f4bd30b0abe664c6924aaL901)，另一個則是scrollHandler()所觸發的[`loadMore()`](https://github.com/mirror-media/mirror-media-nuxt/pull/625/commits/363a0962eb45482acbe22daa3dbe0ae0ce70f29a#diff-9316a1982ecac23af9c2a186560a7ccc751308f4cd0f4bd30b0abe664c6924aaL874)。`scrollHandler()`是將ref改成新的refs就好，然後相關的Condition Variable也設定成新的即可([`shouldLoadMoreNotFeaturedArticles`](https://github.com/mirror-media/mirror-media-nuxt/pull/625/commits/363a0962eb45482acbe22daa3dbe0ae0ce70f29a#diff-9316a1982ecac23af9c2a186560a7ccc751308f4cd0f4bd30b0abe664c6924aaR540-R544))。`loadMore()`則是參考原本的寫法，再去打一次`fetchList()`。此時已經可以往下滑動時載入文章了。上面兩個步驟都做完後，剩下的都很瑣碎了：加入[feature toggle](https://github.com/mirror-media/mirror-media-nuxt/pull/625/commits/363a0962eb45482acbe22daa3dbe0ae0ce70f29a#diff-9316a1982ecac23af9c2a186560a7ccc751308f4cd0f4bd30b0abe664c6924aaR534)、在hook [fetch()時同時拿置頂跟非置頂的文章](https://github.com/mirror-media/mirror-media-nuxt/pull/625/commits/363a0962eb45482acbe22daa3dbe0ae0ce70f29a#diff-9316a1982ecac23af9c2a186560a7ccc751308f4cd0f4bd30b0abe664c6924aaR449-R450)、[加入按鈕並決定是否要顯示](https://github.com/mirror-media/mirror-media-nuxt/pull/625/commits/363a0962eb45482acbe22daa3dbe0ae0ce70f29a#diff-9622e7f1dfb752e48b09644fd5dfb10c1a603320083bd831e5dc37a870822f2cR18-R24)、[點擊看更多按鈕後會載入更多置頂文章](https://github.com/mirror-media/mirror-media-nuxt/pull/625/commits/363a0962eb45482acbe22daa3dbe0ae0ce70f29a#diff-9316a1982ecac23af9c2a186560a7ccc751308f4cd0f4bd30b0abe664c6924aaR893-R898)等。基本上這邊已經完成大部分功能。
3.  [04ff901](https://github.com/mirror-media/mirror-media-nuxt/pull/625/commits/04ff901771ac14c4fd72543c53a68f66f52b5ad2)：重組置頂文章。
    此時發現有個feature沒做到：如果置頂文章不足12篇，則補足到12篇。比如說置頂文章是5篇，則要從非置頂文章中拿7篇去補，而被拿去補的非置頂文章不會重複出現。這邊在fetch()中執行了一個function [`concatArticleList()`](https://github.com/mirror-media/mirror-media-nuxt/pull/625/commits/04ff901771ac14c4fd72543c53a68f66f52b5ad2#diff-9316a1982ecac23af9c2a186560a7ccc751308f4cd0f4bd30b0abe664c6924aaR856-R869)，去計算並重複置頂文章跟非置頂文章的陣列。但這樣的寫法其實有個缺點，就是當我在fetch()中重組陣列，非置頂文章數量會變成不為12篇的倍數：假設經過重組後，非置頂文章一開始僅剩5篇，那在loadMore()後，非置頂文章變成5+12 = 17 篇，以此類推，但就不會是12的倍數。但我目前還沒找到解法，因為鏡週刊的api沒有像其他專案的gql那樣，有開`skip`讓我們跳過特定數量的筆數不打（還是其實有但我沒找到？）
    另外也稍微修正了fetch()中的initList，改成用[`Promise.all`而不是兩個await](https://github.com/mirror-media/mirror-media-nuxt/pull/625/commits/04ff901771ac14c4fd72543c53a68f66f52b5ad2#diff-9316a1982ecac23af9c2a186560a7ccc751308f4cd0f4bd30b0abe664c6924aaR449-R452)，這樣可以節省一點pending的時間。
