### PR TITLE
chore: print member email for debug

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -398,6 +398,7 @@ export default {
         this.loadLatestListInitial()
       }
       this.insertMicroAds()
+      console.log(this.$store.state.membership.userEmail)
     } catch (err) {
       this.$nuxt.context.error({ statusCode: 500 })
     }


### PR DESCRIPTION
由於facebook登入不給http，一定要https。而如果要在nuxt改https，會很多api要跟著改，今天有試著改，但local還是起不來。所以改用這種比較work around的方式：在測試機中把email console.log出來，去看facebook登入但未驗證的email長怎樣，驗證後又會長怎樣。