### PR TITLE
feat: remove gcskeyfile.json requirements on local development environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mirror-media-nuxt
 
-> My gnarly Nuxt.js project
+鏡週刊網站前端
 
 ## Build Setup
 
@@ -26,3 +26,29 @@ For detailed explanation on how things work, check out [Nuxt.js docs](https://nu
 所以目前本專案仍採用classic stable version。
 截至2022.4.28，最新的classic stable version 為1.22.18，開發時請使用~1.22.0的版本。
 To avoid unpredictable error occur when developing, please use Classic Stable version of yarn(~1.22.0).
+
+## Environment Variables
+| 變數名稱 | 資料型態 | 初始值 | 變數說明 |
+| --- | --- | --- | --- |
+| ENV | 字串 | 'local' | 系統環境 |
+| REDIS_READ_HOST | 字串 | 'redis-read-host' | nuxt SSR rendering cache |
+| REDIS_WRITE_HOST | 字串 | 'redis-write-host' | nuxt SSR rendering cache |
+| REDIS_AUTH | 字串 | 'redis-auth' | nuxt SSR rendering cache |
+| NEWEBPAY_KEY | 長度為 32 的字串 | 'newebpay-key' | 藍新支付 API key |
+| NEWEBPAY_IV | 長度為 16 的字串 | 'newebpay-iv' | 藍新支付 API iv |
+| NEWEBPAY_MEMBERSHIP_API_URL | 字串 | 'https://ccore.newebpay.com/MPG/mpg_gateway' | 藍新支付 API URL |
+| NEWEBPAY_PAPERMAG_KEY | 字串 | 'newebpay-papermag-key' | 藍新支付 API key (紙本雜誌) |
+| NEWEBPAY_PAPERMAG_IV | 字串 | 'newebpay-papermag-iv' | 藍新支付 API iv (紙本雜誌) |
+| NEWEBPAY_PAPERMAG_API_URL | 字串 | 'https://ccore.newebpay.com/MPG/mpg_gateway' | 藍新支付 API URL (紙本雜誌) |
+| ISRAFEL_ORIGIN | 字串 | 'israfel-origin' | Israfel URL |
+| API_HOST | 字串 | 'api-host' | API GATEWAY URL |
+| API_HOST_MEMBERSHIP_GATEWAY | 字串 | 'api-host-membership-gateway' | API GATEWAY URL |
+| API_MEMBER_SUBSCRIPTION_GATEWAY | 字串 | 'api-member-subscription-gateway' | API GATEWAY URL |
+| RELEASE_TARGET | 字串 | undefined | |
+| EMAIL_VERIFY_FEATURE_TOGGLE | 'on', 'off' | 'off' | |
+| NO_AD_FEATURE_TOGGLE | 'on', 'off' | 'off' | |
+| TOPIC_LIST_FEATURE_TOGGLE | 'on', 'off' | 'off' | |
+| IS_AD_DISABLE | 布林值 | false | | |
+| PREMIUM_AD_FEATURE_TOGGLE | 布林值 | false | 用 'on' 啟用的數值 ... |
+
+※ 在執行指令時，使用 `key=value` 的前綴來執行，例如：`ENV=dev yarn dev`，即可設定執行時的環境變數。

--- a/README.md
+++ b/README.md
@@ -49,6 +49,6 @@ To avoid unpredictable error occur when developing, please use Classic Stable ve
 | TOPIC_LIST_FEATURE_TOGGLE | 'on', 'off' | 'off' | |
 | IS_AD_DISABLE | 布林值 | false | | |
 | PREMIUM_AD_FEATURE_TOGGLE | 布林值 | false | 用 'on' 啟用的數值 ... |
-| DISABLE_CLOUD_LOGGING | 布林值 | false | 關閉 gcloud/logging 行為 |
+| ENABLE_CLOUD_LOGGING | 布林值 | false | 開啟 gcloud/logging 行為 |
 
 ※ 在執行指令時，使用 `key=value` 的前綴來執行，例如：`ENV=dev yarn dev`，即可設定執行時的環境變數。

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To avoid unpredictable error occur when developing, please use Classic Stable ve
 ## Environment Variables
 | 變數名稱 | 資料型態 | 初始值 | 變數說明 |
 | --- | --- | --- | --- |
-| ENV | 字串 | 'local' | 系統環境 |
+| ENV | 字串 | 'local' | 系統環境，目前已知有；`local`、`dev`、`staging`、`production` 和 `lighthouse` |
 | REDIS_READ_HOST | 字串 | 'redis-read-host' | 讀取用的 Redis hostname or ip |
 | REDIS_WRITE_HOST | 字串 | 'redis-write-host' | 寫入用的 Redis hostname or ip |
 | REDIS_AUTH | 字串 | 'redis-auth' | Reids 驗證用資訊 |
@@ -50,5 +50,6 @@ To avoid unpredictable error occur when developing, please use Classic Stable ve
 | TOPIC_LIST_FEATURE_TOGGLE | 'on', 'off' | 'off' | |
 | IS_AD_DISABLE | 布林值 | false | | |
 | PREMIUM_AD_FEATURE_TOGGLE | 布林值 | false | 用 'on' 啟用的數值 ... |
+| DISABLE_CLOUD_LOGGING | 布林值 | false | 關閉 gcloud/logging 行為 |
 
 ※ 在執行指令時，使用 `key=value` 的前綴來執行，例如：`ENV=dev yarn dev`，即可設定執行時的環境變數。

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ To avoid unpredictable error occur when developing, please use Classic Stable ve
 | API_HOST | 字串 | 'api-host' | API GATEWAY URL |
 | API_HOST_MEMBERSHIP_GATEWAY | 字串 | 'api-host-membership-gateway' | API GATEWAY URL |
 | API_MEMBER_SUBSCRIPTION_GATEWAY | 字串 | 'api-member-subscription-gateway' | API GATEWAY URL |
-| RELEASE_TARGET | 字串 | undefined | |
 | EMAIL_VERIFY_FEATURE_TOGGLE | 'on', 'off' | 'off' | |
 | NO_AD_FEATURE_TOGGLE | 'on', 'off' | 'off' | |
 | TOPIC_LIST_FEATURE_TOGGLE | 'on', 'off' | 'off' | |

--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ To avoid unpredictable error occur when developing, please use Classic Stable ve
 | 變數名稱 | 資料型態 | 初始值 | 變數說明 |
 | --- | --- | --- | --- |
 | ENV | 字串 | 'local' | 系統環境 |
-| REDIS_READ_HOST | 字串 | 'redis-read-host' | nuxt SSR rendering cache |
-| REDIS_WRITE_HOST | 字串 | 'redis-write-host' | nuxt SSR rendering cache |
-| REDIS_AUTH | 字串 | 'redis-auth' | nuxt SSR rendering cache |
-| NEWEBPAY_KEY | 長度為 32 的字串 | 'newebpay-key' | 藍新支付 API key |
-| NEWEBPAY_IV | 長度為 16 的字串 | 'newebpay-iv' | 藍新支付 API iv |
-| NEWEBPAY_MEMBERSHIP_API_URL | 字串 | 'https://ccore.newebpay.com/MPG/mpg_gateway' | 藍新支付 API URL |
+| REDIS_READ_HOST | 字串 | 'redis-read-host' | 讀取用的 Redis hostname or ip |
+| REDIS_WRITE_HOST | 字串 | 'redis-write-host' | 寫入用的 Redis hostname or ip |
+| REDIS_AUTH | 字串 | 'redis-auth' | Reids 驗證用資訊 |
+| NEWEBPAY_KEY | 長度為 32 的字串 | 'newebpay-key' | 藍新支付 API key (Premium 訂閱) |
+| NEWEBPAY_IV | 長度為 16 的字串 | 'newebpay-iv' | 藍新支付 API iv (Premium 訂閱) |
+| NEWEBPAY_MEMBERSHIP_API_URL | 字串 | 'https://ccore.newebpay.com/MPG/mpg_gateway' | 藍新支付 API URL (Premium 訂閱) |
 | NEWEBPAY_PAPERMAG_KEY | 字串 | 'newebpay-papermag-key' | 藍新支付 API key (紙本雜誌) |
 | NEWEBPAY_PAPERMAG_IV | 字串 | 'newebpay-papermag-iv' | 藍新支付 API iv (紙本雜誌) |
 | NEWEBPAY_PAPERMAG_API_URL | 字串 | 'https://ccore.newebpay.com/MPG/mpg_gateway' | 藍新支付 API URL (紙本雜誌) |

--- a/api/tracking.js
+++ b/api/tracking.js
@@ -16,7 +16,7 @@ module.exports = function (req, res, next) {
     const metadata = { resource: { type: 'global' } }
     query.ip = req.clientIp
 
-    if (config.ENV === 'local') {
+    if (config.DISABLE_CLOUD_LOGGING === true) {
       console.log(`[LOG] API tracking`)
       console.log(query)
       return

--- a/api/tracking.js
+++ b/api/tracking.js
@@ -16,7 +16,7 @@ module.exports = function (req, res, next) {
     const metadata = { resource: { type: 'global' } }
     query.ip = req.clientIp
 
-    if (config.DISABLE_CLOUD_LOGGING === true) {
+    if (config.ENABLE_CLOUD_LOGGING === false) {
       console.log(`[LOG] API tracking`)
       console.log(query)
       return

--- a/api/tracking.js
+++ b/api/tracking.js
@@ -8,6 +8,8 @@ const loggingClient = new Logging({
 })
 
 module.exports = function (req, res, next) {
+  if (config.ENV === 'local') return
+
   try {
     res.send({ msg: 'Received.' })
     const query = !isEmpty(req.body) ? req.body : req.query

--- a/api/tracking.js
+++ b/api/tracking.js
@@ -8,8 +8,6 @@ const loggingClient = new Logging({
 })
 
 module.exports = function (req, res, next) {
-  if (config.ENV === 'local') return
-
   try {
     res.send({ msg: 'Received.' })
     const query = !isEmpty(req.body) ? req.body : req.query
@@ -17,6 +15,13 @@ module.exports = function (req, res, next) {
     const log = loggingClient.log(logName)
     const metadata = { resource: { type: 'global' } }
     query.ip = req.clientIp
+
+    if (config.ENV === 'local') {
+      console.log(`[LOG] API tracking`)
+      console.log(query)
+      return
+    }
+
     const entry = log.entry(metadata, query)
     log.write(entry)
   } catch (error) {

--- a/configs/config.js
+++ b/configs/config.js
@@ -26,6 +26,8 @@ const ISRAFEL_ORIGIN = process.env.ISRAFEL_ORIGIN || 'israfel-origin'
 const IS_AD_DISABLE = process.env.IS_AD_DISABLE === 'true' || false
 const PREMIUM_AD_FEATURE_TOGGLE =
   process.env.PREMIUM_AD_FEATURE_TOGGLE === 'on' || false
+const DISABLE_CLOUD_LOGGING =
+  process.env.DISABLE_CLOUD_LOGGING === 'true' || false
 
 // The following variables are given values according to different `ENV`
 let API_HOST = ''
@@ -148,4 +150,5 @@ export {
   NEWEBPAY_MEMBERSHIP_API_URL,
   NEWEBPAY_PAPERMAG_API_URL,
   PREMIUM_AD_FEATURE_TOGGLE,
+  DISABLE_CLOUD_LOGGING,
 }

--- a/configs/config.js
+++ b/configs/config.js
@@ -26,8 +26,7 @@ const ISRAFEL_ORIGIN = process.env.ISRAFEL_ORIGIN || 'israfel-origin'
 const IS_AD_DISABLE = process.env.IS_AD_DISABLE === 'true' || false
 const PREMIUM_AD_FEATURE_TOGGLE =
   process.env.PREMIUM_AD_FEATURE_TOGGLE === 'on' || false
-const DISABLE_CLOUD_LOGGING =
-  process.env.DISABLE_CLOUD_LOGGING === 'true' || false
+const ENABLE_CLOUD_LOGGING = process.env.ENABLE_CLOUD_LOGGING === 'true'
 
 // The following variables are given values according to different `ENV`
 let API_HOST = ''
@@ -150,5 +149,5 @@ export {
   NEWEBPAY_MEMBERSHIP_API_URL,
   NEWEBPAY_PAPERMAG_API_URL,
   PREMIUM_AD_FEATURE_TOGGLE,
-  DISABLE_CLOUD_LOGGING,
+  ENABLE_CLOUD_LOGGING,
 }

--- a/server/index.js
+++ b/server/index.js
@@ -31,11 +31,11 @@ async function start() {
   app.use(requestIp.mw())
 
   app.get('/robots.txt', (req, res, next) => {
-    if (process.env.RELEASE_TARGET === 'prod') {
+    if (process.env.ENV === 'prod') {
       res.type('text/plain').send('User-agent: * \n' + 'Allow: /')
       return
     }
-    if (process.env.RELEASE_TARGET !== 'prod') {
+    if (process.env.ENV !== 'prod') {
       res.type('text/plain').send('User-agent: * \n' + 'Disallow: /')
       return
     }


### PR DESCRIPTION
Use `ENV=local` instead of `END=dev` under local development, so that logs won't be push to gcloud/logging.

**Notice**: This PR could be merged after https://github.com/mirror-media/kubernetes-configs/pull/102 being accpted and merged.
