### PR TITLE
fix(index): problem of render wrong  amount of latest news

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -408,9 +408,15 @@ export default {
 
   methods: {
     shouldUpdateLatestArticle() {
-      const articlesUpdateTimestamp = new Date(
-        this.groupedArticles?.timestamp
-      ).getTime()
+      /*
+       * Safari can't accept original format of time ("YYYY-MM-DD hh:mm:ss") in groupedArticles to generate Date object,
+       * should convert to certain format("YYYY-MM-DDThh:mm:ss") first.
+       */
+      const formattedTimeStamp = this.groupedArticles?.timestamp.replace(
+        / /g,
+        'T'
+      )
+      const articlesUpdateTimestamp = new Date(formattedTimeStamp).getTime()
       const currentTimestamp = new Date().getTime()
       return currentTimestamp - articlesUpdateTimestamp > 1000 * 180
     },
@@ -453,14 +459,16 @@ export default {
       const list = [...this.groupedArticles.latest]
       this.pushLatestItems(list.splice(0, 20))
       this.setLatestTotal(20)
-      this.fileId++
+
+      this.fileId += 1
     },
     async fetchLatestList() {
       if (this.fileId === 5) return []
       const { latest = [] } = await this.$fetchGroupedWithExternal(
         `post_external0${this.fileId}`
       )
-      this.fileId++
+
+      this.fileId += 1
       return latest
     },
     pushLatestItems(items = []) {


### PR DESCRIPTION

### Problem
如果在SSR階段（最新文章尚未完全載入時），如果將頁面滑到最下方，則會少掉部分文章。應該是如果滑到最下方時，會少執行一次`this.pushLatestItems`。
目前採比較workaround的方法：如果在`newLatestLength === 0 && reserveCount < 0`，代表已經沒有json檔可以fetch，這時後就多push 20筆。
但這個做法並沒有找到root cause，所以我覺得有時間的話可以把這段程式碼重構，不然看起來蠻混亂的。