### PR TITLE
fix: fix all the slash warning in scss

### DIFF
--- a/components/ContainerHeader.vue
+++ b/components/ContainerHeader.vue
@@ -326,7 +326,7 @@ export default {
 
 <style lang="scss" scoped>
 $header-top-layer-width: 90%;
-$header-top-layer-padding-x: (100% - $header-top-layer-width) / 2;
+$header-top-layer-padding-x: math.div(100% - $header-top-layer-width, 2);
 $menu-icon-width: 16px;
 $logo-wrapper-margin-x: 8px;
 $header-search-margin-right: 20px;
@@ -363,7 +363,7 @@ header {
       &::before {
         right: calc(
           #{$header-top-layer-padding-x} + #{$share-wrapper-width} + #{$header-search-margin-right} +
-            #{($search-icon-width - $search-field-arrow-width) / 2}
+            #{math.div($search-icon-width - $search-field-arrow-width, 2)}
         );
       }
     }

--- a/components/UiArticleGallery.vue
+++ b/components/UiArticleGallery.vue
@@ -166,10 +166,10 @@ $aspect-ratio--sm: 1.67;
 }
 
 .img-wrapper {
-  padding-top: $width--img-wrapper / $aspect-ratio;
+  padding-top: math.div($width--img-wrapper, $aspect-ratio);
   margin-right: 20px;
   @include media-breakpoint-up(sm) {
-    padding-top: $width--img-wrapper--sm / $aspect-ratio--sm;
+    padding-top: math.div($width--img-wrapper--sm, $aspect-ratio--sm);
     margin-right: 0;
   }
   @include media-breakpoint-up(xl) {
@@ -343,12 +343,12 @@ $padding-top--ad-img: 100%;
     }
 
     .latest-list_item_img {
-      padding-top: $padding-top--ad-img / $aspect-ratio;
+      padding-top: math.div($padding-top--ad-img, $aspect-ratio);
       background-repeat: no-repeat;
       background-size: cover;
       background-position: center;
       @include media-breakpoint-up(sm) {
-        padding-top: $padding-top--ad-img / $aspect-ratio--sm;
+        padding-top: math.div($padding-top--ad-img, $aspect-ratio--sm);
       }
       @include media-breakpoint-up(xl) {
         padding-top: 0;

--- a/components/UiArticleGalleryB.vue
+++ b/components/UiArticleGalleryB.vue
@@ -162,11 +162,11 @@ $aspect-ratio--sm: 1.67;
 }
 
 .img-wrapper {
-  padding-top: $width--img-wrapper / $aspect-ratio;
+  padding-top: math.div($width--img-wrapper, $aspect-ratio);
   margin-right: 20px;
 
   @include media-breakpoint-up(sm) {
-    padding-top: $width--img-wrapper--sm / $aspect-ratio--sm;
+    padding-top: math.div($width--img-wrapper--sm, $aspect-ratio--sm);
     margin-right: 0;
   }
   @include media-breakpoint-up(xl) {
@@ -351,12 +351,12 @@ $padding-top--ad-img: 100%;
     }
 
     .latest-list_item_img {
-      padding-top: $padding-top--ad-img / $aspect-ratio;
+      padding-top: math.div($padding-top--ad-img, $aspect-ratio);
       background-repeat: no-repeat;
       background-size: cover;
       background-position: center;
       @include media-breakpoint-up(sm) {
-        padding-top: $padding-top--ad-img / $aspect-ratio--sm;
+        padding-top: math.div($padding-top--ad-img, $aspect-ratio--sm);
       }
       @include media-breakpoint-up(xl) {
         padding-top: 66.7%;

--- a/components/UiArticleGalleryWithoutFocus.vue
+++ b/components/UiArticleGalleryWithoutFocus.vue
@@ -166,10 +166,10 @@ $aspect-ratio--sm: 1.67;
 }
 
 .img-wrapper {
-  padding-top: $width--img-wrapper / $aspect-ratio;
+  padding-top: math.div($width--img-wrapper, $aspect-ratio);
   margin-right: 20px;
   @include media-breakpoint-up(sm) {
-    padding-top: $width--img-wrapper--sm / $aspect-ratio--sm;
+    padding-top: math.div($width--img-wrapper--sm, $aspect-ratio--sm);
     margin-right: 0;
   }
   @include media-breakpoint-up(xl) {
@@ -343,12 +343,12 @@ $padding-top--ad-img: 100%;
     }
 
     .latest-list_item_img {
-      padding-top: $padding-top--ad-img / $aspect-ratio;
+      padding-top: math.div($padding-top--ad-img, $aspect-ratio);
       background-repeat: no-repeat;
       background-size: cover;
       background-position: center;
       @include media-breakpoint-up(sm) {
-        padding-top: $padding-top--ad-img / $aspect-ratio--sm;
+        padding-top: math.div($padding-top--ad-img, $aspect-ratio--sm);
       }
       @include media-breakpoint-up(xl) {
         padding-top: 0;

--- a/components/UiFlashNews.vue
+++ b/components/UiFlashNews.vue
@@ -233,11 +233,11 @@ a {
 
   $width--arrow: 10px;
   $height--arrow: 5px;
-  $width-half--arrow: $width--arrow / 2;
+  $width-half--arrow: math.div($width--arrow, 2);
 
   $width--arrow--md: 13px;
   $height--arrow--md: 6px;
-  $width-half--arrow--md: $width--arrow--md / 2;
+  $width-half--arrow--md: math.div($width--arrow--md, 2);
 
   &.next::before {
     border-width: 0 $width-half--arrow $height--arrow $width-half--arrow;

--- a/components/UiLoadmoreLoadingIcon.vue
+++ b/components/UiLoadmoreLoadingIcon.vue
@@ -63,7 +63,7 @@ $duration: 1.4s;
     stroke-dashoffset: $offset;
   }
   50% {
-    stroke-dashoffset: ($offset/2);
+    stroke-dashoffset: (math.div($offset, 2));
     transform: rotate(135deg);
   }
   100% {

--- a/components/UiSearchBar.vue
+++ b/components/UiSearchBar.vue
@@ -60,10 +60,10 @@ export default {
 
 <style lang="scss" scoped>
 $header-top-layer-w: 90%;
-$header-top-layer-padding-x: (100% - $header-top-layer-w) / 2;
+$header-top-layer-padding-x: math.div(100% - $header-top-layer-w, 2);
 $search-icon-width: 18px;
 $search-field-arrow-width: 11px;
-$search-field-arrow-width-half: $search-field-arrow-width / 2;
+$search-field-arrow-width-half: math.div($search-field-arrow-width, 2);
 
 .search-bar {
   @include media-breakpoint-up(xl) {
@@ -93,9 +93,10 @@ $search-field-arrow-width-half: $search-field-arrow-width / 2;
     position: absolute;
     top: -12px;
     right: calc(
-      #{$header-top-layer-padding-x} + #{(
-          $search-icon-width - $search-field-arrow-width
-        ) / 2}
+      #{$header-top-layer-padding-x} + #{math.div(
+          $search-icon-width - $search-field-arrow-width,
+          2
+        )}
     );
     border-color: transparent transparent #064f77;
     border-style: solid;

--- a/components/UiStoryContentHandler.vue
+++ b/components/UiStoryContentHandler.vue
@@ -395,7 +395,7 @@ export default {
   }
 
   &__youtube {
-    $aspect-ratio--youtube: 315 / 560;
+    $aspect-ratio--youtube: math.div(315, 560);
 
     .wrapper {
       position: relative;

--- a/components/UiVideoModal.vue
+++ b/components/UiVideoModal.vue
@@ -47,7 +47,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-$aspect-ratio: 9 / 16;
+$aspect-ratio: math.div(9, 16);
 
 .video-modal {
   position: relative;

--- a/components/culture-post-for-premium/ContentHandler.vue
+++ b/components/culture-post-for-premium/ContentHandler.vue
@@ -392,7 +392,7 @@ $quote-color: #4a90e2;
   }
 
   .youtube {
-    $aspect-ratio--youtube: 360 / 640;
+    $aspect-ratio--youtube: math.div(360, 640);
 
     .wrapper {
       position: relative;

--- a/components/culture-post-for-premium/UiListRelatedRedesign.vue
+++ b/components/culture-post-for-premium/UiListRelatedRedesign.vue
@@ -137,7 +137,7 @@ export default {
 
   &__img {
     @function change-height($key) {
-      @return change-width($key) / 3 * 2;
+      @return math.div(change-width($key), 3) * 2;
     }
     display: block;
     align-self: center;

--- a/components/culture-post/ContentHandler.vue
+++ b/components/culture-post/ContentHandler.vue
@@ -439,7 +439,7 @@ $quote-color: #4a90e2;
   }
 
   .youtube {
-    $aspect-ratio--youtube: 315 / 560;
+    $aspect-ratio--youtube: math.div(315, 560);
 
     .wrapper {
       position: relative;

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -501,6 +501,7 @@ module.exports = {
 
   styleResources: {
     scss: '~/scss/*.scss',
+    hoistUseStatements: true,
   },
 
   apollo: {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -933,7 +933,7 @@ $right--events: 10px;
   position: relative;
 
   &--embedded {
-    padding-top: 9 / 16 * 100%;
+    padding-top: math.div(9, 16) * 100%;
 
     div {
       position: absolute;

--- a/scss/_base.scss
+++ b/scss/_base.scss
@@ -1,0 +1,1 @@
+@use 'sass:math';


### PR DESCRIPTION
續： https://github.com/mirror-media/mirror-media-nuxt/pull/642#:~:text=Bug%20C%20%EF%BC%9A%E9%80%99%E6%99%82%E5%80%99%E5%A6%82%E6%9E%9C%E4%B8%8Byarn%20dev%EF%BC%8C%E6%9C%83%E8%B7%B3%E4%B8%80%E5%87%BA%E4%B8%80%E5%A0%86warning%EF%BC%8C%E5%91%8A%E8%A8%B4%E6%88%91%E5%93%AA%E4%BA%9Bscss%E7%9A%84%E5%AF%AB%E6%B3%95%E8%A6%81%E8%A2%AB%E6%A3%84%E7%94%A8%E4%BA%86%EF%BC%88%E5%83%8F%E4%B8%8B%E9%9D%A2%E7%9A%84%E6%A8%A3%E5%AD%90%EF%BC%89%E3%80%82%E9%80%99%E4%B8%A6%E4%B8%8D%E5%BD%B1%E9%9F%BFyarn%20dev%E7%9A%84%E6%99%82%E9%96%93%EF%BC%8C%E5%8F%AA%E6%98%AF%E5%B0%B1%E5%BE%88%E7%85%A9%E3%80%82%E9%82%A3%E8%A6%81%E8%A7%A3%E6%B1%BA%E9%80%99%E5%80%8B%E5%95%8F%E9%A1%8C%EF%BC%8C%E6%9C%89%E4%B8%89%E7%A8%AE%E6%96%B9%E6%B3%95%EF%BC%9A


修正 `node-sass` 更換為 `dart-sass`，`/` 不再作為除法使用所導致的 warning，由於 dart-sass 在 2.0 會完全棄用這個功能，
參考[官方建議](https://sass-lang.com/documentation/breaking-changes/slash-div)，修正既有相關 warning 所提示的程式區塊，
並建立一個 scss 檔案，使用 `@nuxtjs/style-resources` 來進行全域載入，確保 `@use` 語法在最上層。

ref:
* [@nuxtjs/style-resources
TypeScript icon, indicating that this package has built-in type declarations](https://www.npmjs.com/package/@nuxtjs/style-resources)
* [Unable to use Sass built-in modules](https://github.com/nuxt-community/style-resources-module/issues/143)