### PR TITLE
feat(story): change latest news and popular news to  server-side render

### DIFF
--- a/pages/__tests__/story.spec.js
+++ b/pages/__tests__/story.spec.js
@@ -46,33 +46,6 @@ describe('latest list', () => {
     sections: [{ id: '57e1e0e5ee85930e00cad4e9' }],
   }
 
-  test('should render when viewport >= lg', () => {
-    const wrapper = createWrapper(Story, {
-      data() {
-        return {
-          story: storyWithSectionsMock,
-        }
-      },
-    })
-
-    expect(wrapper.find('.latest-list').exists()).toBe(true)
-  })
-
-  test('should not render when viewport < lg', () => {
-    const wrapper = createWrapper(Story, {
-      data() {
-        return {
-          story: storyWithSectionsMock,
-        }
-      },
-      computed: {
-        isDesktopWidth: () => false,
-      },
-    })
-
-    expect(wrapper.find('.latest-list').exists()).toBe(false)
-  })
-
   test('should not render when no sections', () => {
     const wrapper = createWrapper(Story)
 
@@ -83,7 +56,6 @@ describe('latest list', () => {
     const wrapper = createWrapper(Story, {
       data() {
         return {
-          hasLoadedLatestStories: true,
           latestStories: [{}],
           story: storyWithSectionsMock,
         }
@@ -97,7 +69,6 @@ describe('latest list', () => {
     const wrapper = createWrapper(Story, {
       data() {
         return {
-          hasLoadedLatestStories: true,
           story: storyWithSectionsMock,
         }
       },
@@ -106,16 +77,17 @@ describe('latest list', () => {
     expect(wrapper.find('.latest-list').exists()).toBe(false)
   })
 
-  test('should render the proper latest stories', async () => {
+  test('should render the proper latest stories', () => {
     const mockStorySlug = '20201007fin003'
     const mockLatestStoryWithCurrentStorySlug = { slug: mockStorySlug }
     const mockLatestStories = [
       mockLatestStoryWithCurrentStorySlug,
-      ...Array(8).fill({}),
+      ...Array(6).fill({}),
     ]
     const wrapper = createWrapper(Story, {
       data() {
         return {
+          doesHaveLatestStories: true,
           story: storyWithSectionsMock,
         }
       },
@@ -125,36 +97,9 @@ describe('latest list', () => {
       },
     })
 
-    wrapper.get('.lazy-latest-list').vm.$emit('load')
-    await wrapper.vm.$nextTick()
-
     const { items } = wrapper.get('.latest-list').props()
 
-    expect(items).toHaveLength(6)
     expect(items).not.toContainEqual(mockLatestStoryWithCurrentStorySlug)
-  })
-
-  /**
-   * 由於 latest list 的內容是需要打 API 取得，又沒 SSR，所以內容一開始會是空的
-   * 其底下的元件因此會往上擠，出現在視埠（viewport）之中，導致這些應該被 lazy load 的元件，在一開始就被載入進來
-   * 為了避免這個問題，需要在一開始元件還沒內容時，就給它一個固定高度 100vh，以確保其底下的元件不會出現在視埠之中
-   * 直到元件有內容後，再拿掉固定高度，讓其底下元件達到 lazy load 的效果
-   */
-  test('its height should be 100vh when latest stories are not loaded', async () => {
-    const wrapper = createWrapper(Story, {
-      data() {
-        return {
-          story: storyWithSectionsMock,
-        }
-      },
-    })
-    const lazyLatestList = wrapper.get('.lazy-latest-list')
-
-    expect(lazyLatestList.element.style.height).toBe('100vh')
-
-    await wrapper.setData({ latestStories: [{}] })
-
-    expect(lazyLatestList.element.style.height).toBe('')
   })
 })
 

--- a/pages/story/_slug.vue
+++ b/pages/story/_slug.vue
@@ -362,13 +362,15 @@ export default {
         this.fetchPopularStories(),
         this.fetchLatestStories(),
       ])
-    if (popularStoriesResponse === 'rejected') {
-      this.popularStories.value = []
-    } else if (latestStoriesResponse === 'rejected') {
-      this.latestStories.value = []
+    if (popularStoriesResponse.status === 'fulfilled') {
+      this.popularStories = popularStoriesResponse.value
     } else {
-      this.popularStories = popularStoriesResponse.value || []
-      this.latestStories = latestStoriesResponse.value || []
+      this.popularStories = []
+    }
+    if (latestStoriesResponse.status === 'fulfilled') {
+      this.latestStories = latestStoriesResponse.value
+    } else {
+      this.latestStories = []
     }
   },
 


### PR DESCRIPTION
### Target 
將文章側欄的熱門文章與最新文章改為SSR，並調整相關的程式碼。

### [bfc537f](https://github.com/mirror-media/mirror-media-nuxt/pull/698/commits/bfc537f7833065643b2a5adf16ee7a32cb8f3eb7): 調整熱門文章為SSR。
這個commit只有調整熱門文章，在virtual DOM的地方，主要是將[`<LazyRenderer>`拔掉](https://github.com/mirror-media/mirror-media-nuxt/pull/698/commits/bfc537f7833065643b2a5adf16ee7a32cb8f3eb7#diff-5cf06ab598e656ea4e78d40cdb1d16ac74f3f7d918edb224f7398fefd2a9caa5R139-R148)，並在nuxt server-side hook [`fetch()`加入`Promise.allSettled()`](https://github.com/mirror-media/mirror-media-nuxt/pull/698/commits/bfc537f7833065643b2a5adf16ee7a32cb8f3eb7#diff-5cf06ab598e656ea4e78d40cdb1d16ac74f3f7d918edb224f7398fefd2a9caa5R285-R293)
> 這邊之所以使用Promise.allSettled，除了是因為之後還要拿最新文章的資料，所以不能單純寫async await。而且我也不希望使用Promise.all，因為Promise.all的特性，若其中一個promise被rejected的話，會使得整個Promise.all被rejected，但我希望任何promise的結果是independent的，並針對不同promise做不同handle）。

由於熱門文章並不是story的主要內容，所以就算Promise被rejected了，我也只是將this.popularStories assign為空陣列，而不是像[首頁那樣跳nuxt.error](https://github.com/mirror-media/mirror-media-nuxt/blob/dev/pages/index.vue#L194)


 ###  [c5f357f](https://github.com/mirror-media/mirror-media-nuxt/pull/698/commits/c5f357f1dc784e7c77c5fd3ddb7c086d6c6a8d27): 調整最新文章為SSR
由於最新文章是打API，而不是像熱門文章直接拿gcs json檔，所以有些調整比較複雜，我也寫得比較亂，請搭配以下順序做code review：
- [將fetchPopularStories()與fetchLatestStories()的位置，從fetch()的最上方改至最下方](https://github.com/mirror-media/mirror-media-nuxt/pull/698/commits/c5f357f1dc784e7c77c5fd3ddb7c086d6c6a8d27#diff-5cf06ab598e656ea4e78d40cdb1d16ac74f3f7d918edb224f7398fefd2a9caa5R360-R372)：由於fetchLatestStories()會需要傳一個參數`this.sectionId`，但這個參數是只有執行`processPostResponse()`後，才拿得到，如果放在最前方的話，`this.sectionId`會是default值`"other"`，造成資料fetch錯誤。
- [刪除變數`hasLoadedLatestStories`](https://github.com/mirror-media/mirror-media-nuxt/pull/698/commits/c5f357f1dc784e7c77c5fd3ddb7c086d6c6a8d27#diff-5cf06ab598e656ea4e78d40cdb1d16ac74f3f7d918edb224f7398fefd2a9caa5L383)：該變數原為控制側欄的UI用，由於原本server side時，並沒有最新文章，但仍希望最新文章能固定100vh的留白，避免進入client side後側欄UI位移過多，造成使用者體驗不佳。但如果將最新文章改為server side，就沒有這個困擾。
- [調整變數 `shouldOpenLatestList`](https://github.com/mirror-media/mirror-media-nuxt/pull/698/commits/c5f357f1dc784e7c77c5fd3ddb7c086d6c6a8d27#diff-5cf06ab598e656ea4e78d40cdb1d16ac74f3f7d918edb224f7398fefd2a9caa5R470): 由於改為SSR，在server side的時候並沒有辦法拿到螢幕寬度，進而判斷`this.isDesktopWidth`是true 還是 false，故刪除。並改由css控制RWD。
- 調整測試檔
