### PR TITLE
feat: add LINE Pay records to /profile/purchase page (posts and pay records)

### DIFF
--- a/api/linepay.js
+++ b/api/linepay.js
@@ -250,7 +250,7 @@ async function getPaymentInfo(data, isPreapproved = false) {
       error,
       'ApiError',
       'error on getting LINEPay payment info',
-      { data, isPreapproved }
+      { data, isPreapproved, errorData: error.data }
     )
   }
 }

--- a/api/linepay.js
+++ b/api/linepay.js
@@ -474,7 +474,7 @@ async function getLINEPayInfoOfRecurring(req, res) {
     subscription.orderNumber = orderNumber
 
     // send Request API to LINE Pay server to retreive payment info
-    const paymentInfo = await getPaymentInfo(subscription)
+    const paymentInfo = await getPaymentInfo(subscription, true)
 
     // write draft payment
     await createDraftPayment(paymentInfo.body, subscription)

--- a/api/linepay.js
+++ b/api/linepay.js
@@ -377,24 +377,14 @@ async function getLINEPayInfoOfOneTime(req, res) {
     // write draft payment
     await createDraftPayment(paymentInfo.body, subscription)
 
-    if (paymentInfo.body.returnCode === '0000') {
-      return sendResponse({
-        status: REQUEST_STATUS.SUCCESS,
-        data: {
-          title: 'Succeed in getting payment info.',
-          paymentInfo: paymentInfo.body.info,
-        },
-        res,
-      })
-    } else {
-      return sendResponse({
-        status: REQUEST_STATUS.FAIL,
-        data: {
-          title: 'Failed to get payment info.',
-        },
-        res,
-      })
-    }
+    return sendResponse({
+      status: REQUEST_STATUS.SUCCESS,
+      data: {
+        title: 'Succeed in getting payment info.',
+        paymentInfo: paymentInfo.body.info,
+      },
+      res,
+    })
   } catch (error) {
     const annotatingError = errors.helpers.wrap(
       error,
@@ -479,24 +469,14 @@ async function getLINEPayInfoOfRecurring(req, res) {
     // write draft payment
     await createDraftPayment(paymentInfo.body, subscription)
 
-    if (paymentInfo.body.returnCode === '0000') {
-      return sendResponse({
-        status: REQUEST_STATUS.SUCCESS,
-        data: {
-          title: 'Succeed in getting payment info.',
-          paymentInfo: paymentInfo.body.info,
-        },
-        res,
-      })
-    } else {
-      return sendResponse({
-        status: REQUEST_STATUS.FAIL,
-        data: {
-          title: 'Failed to get payment info.',
-        },
-        res,
-      })
-    }
+    return sendResponse({
+      status: REQUEST_STATUS.SUCCESS,
+      data: {
+        title: 'Succeed in getting payment info.',
+        paymentInfo: paymentInfo.body.info,
+      },
+      res,
+    })
   } catch (error) {
     const annotatingError = errors.helpers.wrap(
       error,

--- a/api/member-subscription-proxy-v2.js
+++ b/api/member-subscription-proxy-v2.js
@@ -1,5 +1,9 @@
 /*
- * This api endpoint might replace v0 in the future.
+ * This api endpoint is served as a proxy between front-end page and Israfel GraphQL api endpoint.
+ * This api is built with request authenication by verifing header of request.
+ * GraphQL request related to member list use this endpoint is recommanded.
+ * Customized query or mutation in apigateway should migrat to this endpoint in the future.
+ * This endpoint might replace v0 in the future.
  * The adventage of this endpoint is removing dependacies on apigateway.
  */
 

--- a/api/member-subscription-proxy-v2.js
+++ b/api/member-subscription-proxy-v2.js
@@ -1,0 +1,15 @@
+/*
+ * This api endpoint might replace v0 in the future.
+ * The adventage of this endpoint is removing dependacies on apigateway.
+ */
+
+import express from 'express'
+import { ISRAFEL_ORIGIN } from '../configs/config.js'
+import requestAuthentication from '../serverMiddleware/requestAuthentication.js'
+import { createProxy } from './helpers'
+
+const app = express()
+app.use(requestAuthentication())
+app.use('/', createProxy(`${ISRAFEL_ORIGIN}/api/graphql/member`))
+
+module.exports = app

--- a/apollo/queries/memberSubscriptionQuery.gql
+++ b/apollo/queries/memberSubscriptionQuery.gql
@@ -116,4 +116,38 @@ query fetchSubscriptionPayments($firebaseId: String!) {
   }
 }
 
+query fetchSubscriptionPaymentsWithLINEPay($firebaseId: String!) {
+  member(where: { firebaseId: $firebaseId }) {
+    email
+    subscription(orderBy: { periodEndDatetime: desc }) {
+      orderNumber
+      frequency
+      periodEndDatetime
+      oneTimeEndDatetime
+      paymentMethod
+      linePayStatus
+      newebpayPayment(orderBy: { paymentTime: desc }) {
+        paymentMethod
+        paymentTime
+        amount
+        cardInfoLastFour
+        createdAt
+        status
+      }
+      linepayPayment(orderBy: { transactionTime: desc }) {
+        payInfoMethod
+        transactionTime
+        amount
+        maskedCreditCardNumber
+        createdAt
+        returnCode
+      }
+      googlePlayPayment(orderBy: { transactionDatetime: desc }) {
+        transactionDatetime
+        amount
+      }
+    }
+  }
+}
+
 

--- a/apollo/queries/memberSubscriptionQuery.gql
+++ b/apollo/queries/memberSubscriptionQuery.gql
@@ -50,6 +50,22 @@ query fetchOneTimeSubscriptions($firebaseId: String!) {
     }
   }
 }
+
+query fetchOneTimeSubscriptionsWithLINEPay($firebaseId: String!) {
+  member(where: { firebaseId: $firebaseId }) {
+    email
+    subscription(
+      where: { AND: [{ frequency: one_time, isActive: true, OR: [{ status: paid }, { linePayStatus: paid }] }] }
+      orderBy: { oneTimeEndDatetime: desc }
+    ) {
+      frequency
+      orderNumber
+      paymentMethod
+      postId
+      oneTimeEndDatetime
+    }
+  }
+}
 query fetchRecurringSubscription($firebaseId: String!) {
   member(where: { firebaseId: $firebaseId }) {
     email

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -400,6 +400,7 @@ module.exports = {
               ignorePaths: [
                 '/papermag/return',
                 '/subscribe/return',
+                '/subscribe/confirm',
                 '/campaigns',
                 '/projects',
                 '/dist',

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -292,6 +292,10 @@ module.exports = {
       handler: '~/api/member-subscription-proxy.js',
     },
     {
+      path: `/${API_PATH_FRONTEND}/member-subscription/v2`,
+      handler: '~/api/member-subscription-proxy-v2.js',
+    },
+    {
       path: `/${API_PATH_FRONTEND}/newebpay/v1`,
       handler: '~/api/newebpay.js',
     },

--- a/pages/profile/purchase.vue
+++ b/pages/profile/purchase.vue
@@ -112,6 +112,8 @@ export default {
   },
 
   async created() {
+    if (process.server) return
+
     try {
       if (this.isPremium || this.isBasic) {
         this.memberShipStatus = await this.$getMemberShipStatus(

--- a/pages/subscribe/confirm.vue
+++ b/pages/subscribe/confirm.vue
@@ -192,7 +192,8 @@ export default {
       }
 
       // return result and update data attritube
-      if (confirmResult.returnCode !== '0000') {
+      const ok = '0000'
+      if (confirmResult.returnCode !== ok) {
         return {
           status: 'fail',
           errorData: {

--- a/pages/subscribe/info.vue
+++ b/pages/subscribe/info.vue
@@ -415,10 +415,11 @@ export default {
           } else if (status === REQUEST_STATUS.FAIL) {
             window.alert('您的訂閱資料有誤，請修正後再嘗試')
             this.isLoading = false
-            return
           } else {
             throw new Error(message)
           }
+
+          return
         }
 
         // emit apiGateWay

--- a/utils/memberSubscription.js
+++ b/utils/memberSubscription.js
@@ -183,7 +183,7 @@ async function fireGqlRequestNewApi(query, variables, context) {
     headers: {
       'content-type': 'application/json',
       Authorization: `Bearer ${firebaseToken}`,
-      'Cache-Control': 'no-store',
+      'Cache-Control': 'no-cache',
     },
   })
 

--- a/utils/memberSubscription.js
+++ b/utils/memberSubscription.js
@@ -216,7 +216,7 @@ function getMemberPayRecords(subscriptionList) {
         methodNote: `(${newebpayPayment.cardInfoLastFour || ''})`,
         price: newebpayPayment.amount,
         status: newebpayPayment.status,
-        createAt: newebpayPayment.createdAt,
+        createdAt: newebpayPayment.createdAt,
       }
       payRecords.push(payRecord)
     })
@@ -233,7 +233,7 @@ function getMemberPayRecords(subscriptionList) {
         )})`,
         price: linepayPayment.amount,
         status: LINEPayStatusMap[subscription.linePayStatus] ?? '',
-        createAt: linepayPayment.createdAt,
+        createdAt: linepayPayment.createdAt,
       }
       payRecords.push(payRecord)
     })
@@ -248,7 +248,7 @@ function getMemberPayRecords(subscriptionList) {
         methodNote: '',
         price: payment.amount,
         status: '',
-        createAt: payment.createdAt ?? payment.transactionDatetime,
+        createdAt: payment.createdAt ?? payment.transactionDatetime,
       }
       payRecords.push(payRecord)
     })
@@ -256,7 +256,7 @@ function getMemberPayRecords(subscriptionList) {
 
   // sort all records by date_dsc
   payRecords.sort((recordA, recordB) => {
-    return new Date(recordB.createAt) - new Date(recordA.createAt)
+    return new Date(recordB.createdAt) - new Date(recordA.createdAt)
   })
 
   return payRecords

--- a/utils/memberSubscription.js
+++ b/utils/memberSubscription.js
@@ -178,7 +178,9 @@ function getMemberPayRecords(subscriptionList) {
     subscription.newebpayPayment?.forEach((newebpayPayment) => {
       const payRecord = {
         number: subscription.orderNumber,
-        date: getFormatDateWording(newebpayPayment.paymentTime),
+        date: getFormatDateWording(
+          newebpayPayment.createdAt ?? newebpayPayment.paymentTime
+        ),
         type: getSubscriptionTypeWording(subscription.frequency),
         method: newebpayPayment.paymentMethod,
         methodNote: `(${newebpayPayment.cardInfoLastFour || ''})`,
@@ -191,7 +193,9 @@ function getMemberPayRecords(subscriptionList) {
     subscription.googlePlayPayment?.forEach((payment) => {
       const payRecord = {
         number: subscription.orderNumber,
-        date: getFormatDateWording(payment.transactionDatetime),
+        date: getFormatDateWording(
+          payment.createdAt ?? payment.transactionDatetime
+        ),
         type: '',
         method: 'Google Play 續扣',
         methodNote: '',

--- a/utils/memberSubscription.js
+++ b/utils/memberSubscription.js
@@ -1,6 +1,6 @@
 import { print } from 'graphql/language/printer'
 import axios from 'axios'
-import moment from 'moment'
+import _ from 'lodash'
 import { API_PATH_FRONTEND } from '~/configs/config.js'
 import {
   fetchMemberSubscriptions,
@@ -463,18 +463,16 @@ async function getMemberSubscribePosts(subscriptionList) {
     })
 
     const post = {
-      id: getUniquePostId(subscription.postId, subscription.oneTimeEndDatetime),
+      id: subscription.postId,
       title: correspondPost.title,
       url: `/story/${correspondPost.slug}`,
       deadline: getFormatDateWording(subscription.oneTimeEndDatetime),
     }
     postList.push(post)
   })
-  return postList
-}
 
-function getUniquePostId(postId, endDateTime) {
-  return `${postId}-${moment(endDateTime).format('YYYYMMDDHHmmss')}`
+  // return newest unique posts
+  return _.uniqBy(postList, 'id')
 }
 
 async function getMemberShipStatus(context, memberShipStatusName) {

--- a/utils/memberSubscription.js
+++ b/utils/memberSubscription.js
@@ -1,5 +1,6 @@
 import { print } from 'graphql/language/printer'
 import axios from 'axios'
+import moment from 'moment'
 import {
   fetchMemberSubscriptions,
   fetchMemberBasicInfo,
@@ -400,7 +401,7 @@ async function getMemberSubscribePosts(subscriptionList) {
     })
 
     const post = {
-      id: subscription.postId,
+      id: getUniquePostId(subscription.postId, subscription.oneTimeEndDatetime),
       title: correspondPost.title,
       url: `/story/${correspondPost.slug}`,
       deadline: getFormatDateWording(subscription.oneTimeEndDatetime),
@@ -408,6 +409,10 @@ async function getMemberSubscribePosts(subscriptionList) {
     postList.push(post)
   })
   return postList
+}
+
+function getUniquePostId(postId, endDateTime) {
+  return `${postId}-${moment(endDateTime).format('YYYYMMDDHHmmss')}`
 }
 
 async function getMemberShipStatus(context, memberShipStatusName) {

--- a/utils/memberSubscription.js
+++ b/utils/memberSubscription.js
@@ -204,7 +204,7 @@ function getMemberPayRecords(subscriptionList) {
 
   // sort all records by date_dsc
   payRecords.sort((recordA, recordB) => {
-    return new Date(recordA.createdAt) - new Date(recordB.createdAt)
+    return new Date(recordB.createAt) - new Date(recordA.createAt)
   })
 
   return payRecords


### PR DESCRIPTION
* feat: publish failed Confirm API result to PubSub 
將 `Confirm API` 失敗的結果送入 PubSub，在 `linepayPayment` 紀錄中留下錯誤資訊，並使對應的 `subscription` 中的付款狀態轉為 `fail`

* fix: tell service worker to ignore /subscribe/confirm page
同 `/subscribe/return` 的邏輯

* fix: typo cause unexpected order of payment 
修正 typo 導致訂閱紀錄頁，付款紀錄區塊中，資料未依照時間順序，由近到遠排序

* fix: duplicated postId cause front-end render warning
修正在有重複文章訂閱紀錄的情況下，導致前端渲染時，會出現 duplicated key 的 warning

* feat: use created field as default display
使用建立時間作為付款紀錄的預設時間顯示

* fix: prevent query on server side when data is used by client-only component
修正資料請求在 client-side 才需要的情況下，卻在 server-side 也執行，而產生浪費的行為

* feat: add /api/v2/member-subscription/v2 endpoint
增加 v2 的 endpoint，作為 `mirror-media-nuxt` 向 `Israfel` 發起 GraphQL 請求，而不經過 `apigateway` 使用

* feat: add LINE Pay records to one-time subscription query
訂閱紀錄頁，訂閱中文章資訊增加使用 LINE Pay 付款的文章紀錄

* feat: add LINE Pay records to payments
訂閱記錄頁，付款紀錄增加使用 LINE Pay 付款的紀錄