### PR TITLE
fix(index): latest news is sorted by `publishedDate` of article

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -300,7 +300,7 @@ export default {
       return currentPage < maxPage
     },
     latestItems() {
-      return _.uniqBy(
+      const listWithUniqueItems = _.uniqBy(
         this.latestList.items,
         function identifyDuplicateById(item) {
           if (item.isMicroAd) {
@@ -309,6 +309,9 @@ export default {
           return item.id
         }
       )
+      return listWithUniqueItems.sort(function (currentItem, nextItem) {
+        return nextItem.publishedTimeStamp - currentItem.publishedTimeStamp
+      })
     },
 
     isValidEventModItem() {
@@ -483,7 +486,13 @@ export default {
       this.latestList.total = total
     },
     transformContentOfLatestItem(item = {}) {
-      const { id = '', title = '', brief, sections = [] } = item
+      const {
+        id = '',
+        title = '',
+        brief,
+        sections = [],
+        publishedDate = '',
+      } = item
 
       return {
         id,
@@ -495,6 +504,7 @@ export default {
         imgSrc: getImg(item),
         label: getLabel(item),
         sectionName: item.partner ? 'external' : sections[0]?.name,
+        publishedTimestamp: new Date(publishedDate).getTime(),
       }
     },
     async loadMoreLatestItems(state) {


### PR DESCRIPTION
Because latest news will fetch at server side `fetch()` and client side `mounted()`,
to prevent newer  article is assert at the last of array `latestItem`,
we sort this array when `latestList` is update.