### PR TITLE
fix(pages/index): infinite loop if user scroll to bottom at server side

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -8,7 +8,6 @@
         @sendGa:next="sendGaForClick('breakingnews up')"
         @sendGa:prev="sendGaForClick('breakingnews down')"
       />
-
       <ContainerGptAd class="home__ad home__ad--hd" pageKey="home" adKey="HD" />
 
       <section class="editor-choices-container">
@@ -90,8 +89,8 @@
               @sendGa="sendGaForClick('latest')"
             />
             <UiInfiniteLoading
-              v-if="latestItems.length > 3"
-              @infinite="loadMoreLatestItems"
+              v-if="hasLoadedFirstGroupedArticle && latestItems.length > 3"
+              @infinite="handleInfiniteLoad"
             />
           </section>
         </div>
@@ -241,7 +240,8 @@ export default {
       },
 
       hasScrolled: false,
-
+      hasLoadedFirstGroupedArticle: false,
+      isNoNeedToFetchLatestList: false,
       observerOfLastSecondFocusList: undefined,
       canFixLastFocusList: false,
       shouldFixLastFocusList: false,
@@ -292,12 +292,6 @@ export default {
       return articles.map((article) =>
         transformContent(article, this.isPremiumMember)
       )
-    },
-    doesHaveAnyLatestItemsLeftToLoad() {
-      const { total, maxResults, page: currentPage } = this.latestList
-      const maxPage = Math.ceil(total / maxResults)
-
-      return currentPage < maxPage
     },
     latestItems() {
       const listWithUniqueItems = _.uniqBy(
@@ -400,6 +394,7 @@ export default {
         this.groupedArticles = groupedResponse
         this.loadLatestListInitial()
       }
+      this.hasLoadedFirstGroupedArticle = true
       this.insertMicroAds()
     } catch (err) {
       this.$nuxt.context.error({ statusCode: 500 })
@@ -466,7 +461,10 @@ export default {
       this.fileId += 1
     },
     async fetchLatestList() {
-      if (this.fileId === 5) return []
+      if (this.fileId === 5) {
+        this.isNoNeedToFetchLatestList = true
+        return []
+      }
       const { latest = [] } = await this.$fetchGroupedWithExternal(
         `post_external0${this.fileId}`
       )
@@ -507,63 +505,40 @@ export default {
         publishedTimestamp: new Date(publishedDate).getTime(),
       }
     },
-    async loadMoreLatestItems(state) {
-      try {
-        const groupArticleLength = this.groupedArticles.latest?.length
-        const latestLength = this.latestList?.items?.length
-        const reserveCount = groupArticleLength - latestLength
-        let newLatestLength
-        if (reserveCount < 20 || (reserveCount === 20 && this.fileId === 5)) {
-          const newLatest = await this.fetchLatestList()
-          newLatestLength = newLatest.length
-          this.groupedArticles.latest?.push(
-            ...newLatest.map((item) => {
-              return {
-                id: item.slug,
-                ...item,
-              }
-            })
-          )
-        }
-
-        const oldestId = this.latestList?.items[latestLength - 1].id
-        let indexOfOlndex
-        this.groupedArticles.latest?.map((item, i) => {
-          if (item.id === oldestId) {
-            indexOfOlndex = i + 1
-          }
-        })
-
-        /*
-         * when page is initialized at server side, if user scroll to the bottom of page,
-         * methods `this.pushLatestItems` will executed one less time.
-         * The root cause has not been found and resolved, but we take the workaround solution temporarily,
-         * which is calculate length of `newLatest`, if it is 0, which means don't remain latest news
-         * have to fetch from backend, then execute`pushLatestItems` by pushing double amount of latest news,
-         * and stop the load.
-         */
-        if (newLatestLength === 0 && reserveCount < 0) {
-          this.pushLatestItems(
-            this.groupedArticles.latest.slice(indexOfOlndex, indexOfOlndex + 40)
-          )
-          state.complete()
-          return
-        } else {
-          this.pushLatestItems(
-            this.groupedArticles.latest.slice(indexOfOlndex, indexOfOlndex + 20)
-          )
-        }
-
-        this.latestList.page++
-
-        state.loaded()
-
-        this.sendGa('scroll', 'loadmore', this.latestList.page)
-      } catch (err) {
-        // eslint-disable-next-line no-console
-        console.error(err)
-        state.error()
+    async handleInfiniteLoad(state) {
+      if (!this.hasLoadedFirstGroupedArticle) {
+        return
       }
+      if (this.isNoNeedToFetchLatestList) {
+        state.complete()
+      } else {
+        await this.loadMoreLatestItems()
+        state.loaded()
+      }
+      this.sendGa('scroll', 'loadmore', this.latestList.page)
+    },
+    async loadMoreLatestItems() {
+      this.latestList.page += 1
+      if (
+        this.groupedArticles?.latest.length <=
+        this.latestList.maxResults * (this.latestList.page + 1)
+      ) {
+        const newLatest = await this.fetchLatestList()
+        this.groupedArticles.latest?.push(
+          ...newLatest.map((item) => {
+            return {
+              id: item.slug,
+              ...item,
+            }
+          })
+        )
+      }
+      this.pushLatestItems(
+        this.groupedArticles.latest.slice(
+          this.latestList.maxResults * this.latestList.page,
+          this.latestList.maxResults * (this.latestList.page + 1)
+        )
+      )
     },
 
     async loadFixedEventMod() {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -89,7 +89,7 @@
               @sendGa="sendGaForClick('latest')"
             />
             <UiInfiniteLoading
-              v-if="hasLoadedFirstGroupedArticle && latestItems.length > 3"
+              v-if="latestItems.length > 3"
               @infinite="handleInfiniteLoad"
             />
           </section>


### PR DESCRIPTION
## Problem Description
當使用者進入首頁後，如果在frontend server-side 時，使用者就滑到最下方，將造成client side時，網頁會無法正確render資料。
如下影片所示：
https://imgur.com/a/8ny8Sti
發現是因為滑到最底部時，會去fetch最新文章的json檔，同時也會去執行infinite-loading套件的函式 `load()`（這邊只知道函式將新拿到的json檔render出來，並把最底部往下推），但「fetch 最新文章json檔」跟「使用套件函式」的邏輯不一樣，所以會有「沒有fetch 新的json檔」卻「執行load()」的情況發生，導致最底部一直無法往下推，進而無限重複執行 load() 。

## Commit Detail 
需先說明最新文章相關的data，以及其用途：
1. `this.groupedArticles`: 為fetch json檔後所得到的原始資料，其中有choice（編輯精選）與latest（最新文章）。總共fetch 四份json檔，一份json檔的`latest`共有50個object，一個object為一份最新文章的相關資訊，所以總共有200篇最新文章。
2. `this.latestList`: 共有4個property: `items, total, maxResults, page`，`items`為一陣列，透過methods `this.pushLatestItems`將groupedArticle.latest推進該陣列。`maxResults`為一次push進去的數量，目前是20筆；`page`則決定從groupedArticle push 進入`latestList`的begin and end index。
3. `this.latestItems`：真正render在頁面上的最新文章，會做deduplicate跟sorting。它不是這次的主角。不過就命名與功能上而言，都與`this.latestList.items`相似，之後可再花時間修掉，避免過多功能重複的程式碼影響可閱讀性。

接下來，將說明本次的改動細節：
- 調整既有函式[`loadMoreLatestItems()`](https://github.com/mirror-media/mirror-media-nuxt/pull/749/commits/335c70838c1236b043546b2305ca35cee30db43a#diff-02281a80fab758cb4e8e8359b222a8a5afeaa9d5a7ba858f15d852f1f8969ecfR520)：將其專注在資料串接與處理，觸發infinite-loading套件的函式，則由另一新增函式`handleInfiniteLoad()`處理。該函式做了兩件事情：
  1. 當滿足[特定條件](https://github.com/mirror-media/mirror-media-nuxt/pull/749/commits/335c70838c1236b043546b2305ca35cee30db43a#diff-02281a80fab758cb4e8e8359b222a8a5afeaa9d5a7ba858f15d852f1f8969ecfR523-R524)時，執行函式`fetchLatestList()`，拿下一份json檔，如果4份 json檔都被拿完了，會將`this.isNoNeedToFetchLatestList` assign 為true。
    > 特定條件：「當`groupedArticle`的數量**即將**少於`maxResults * ( page + 1) `」。舉例，假設現在的`groupedArticle`是50筆，此時`maxResults * ( page +1 )` 為`20 * (2  + 1)`，代表下次執行`loadMoreLatestItems()`時，`groupedArticle`的數量，會不夠被push進`this.latestList`，所以必須先執行fetchLatestList()，拿到足夠的`groupedArticle`。
  3. 執行`this.pushLatestItems()`，將groupedArticle依據maxResult跟page，push進`this.latestList`。

- 新增`this.hasLoadedFirstGroupedArticle`，只有當`mounted()`後才能觸發infinite loading，避免在server side就觸發，造成未知的side effect。

- 新增函式[`handleInfiniteLoad()`](https://github.com/mirror-media/mirror-media-nuxt/pull/749/commits/335c70838c1236b043546b2305ca35cee30db43a#diff-02281a80fab758cb4e8e8359b222a8a5afeaa9d5a7ba858f15d852f1f8969ecfR508)，執行infinite-loading套件的函式 `state.loaded()`或`state.completed()`：當`this.isNoNeedToFetchLatestList` 為true時，則執行`state.completed()`，代表不再handle任何scroll event，因此不再觸發函式`handleInfiniteLoad()`，反之則執行函式`fetchLatestList()`。
