### PR TITLE
feat: allow LINE Pay option for monthly/yearly subscription

### DIFF
--- a/apollo/queries/memberSubscriptionQuery.gql
+++ b/apollo/queries/memberSubscriptionQuery.gql
@@ -87,10 +87,13 @@ query fetchRecurringSubscription($firebaseId: String!) {
         paymentMethod
         cardInfoLastFour
       }
+      linepayPayment(orderBy: { transactionTime: desc }) {
+        payInfoMethod
+        maskedCreditCardNumber
+      }
     }
   }
 }
-
 query fetchSubscriptionPayments($firebaseId: String!) {
   member(where: { firebaseId: $firebaseId }) {
     email

--- a/components/MemberShipStatus.vue
+++ b/components/MemberShipStatus.vue
@@ -55,6 +55,7 @@
 <script>
 import UiMembershipButtonPrimary from './UiMembershipButtonPrimary.vue'
 import UiMembershipButtonSecondary from './UiMembershipButtonSecondary.vue'
+import { MemberType } from '~/constants/common'
 export default {
   components: {
     UiMembershipButtonPrimary,
@@ -80,34 +81,32 @@ export default {
       return this.isPremium ? '會員等級：Premium會員' : '會員等級：Basic 會員'
     },
     premiumPlan() {
-      return this.memberShipStatus.name === 'subscribe_yearly' ||
-        this.memberShipStatus.name === 'subscribe_yearly_update_to_monthly' ||
-        this.memberShipStatus.name === 'subscribe_yearly_disturb'
+      return this.memberShipStatus.name === MemberType.Yearly ||
+        this.memberShipStatus.name === MemberType.YearlyToMonthly ||
+        this.memberShipStatus.name === MemberType.YearlyDisturbed
         ? '年訂閱'
         : '月訂閱'
     },
     canUpdateToYearly() {
       return (
-        this.memberShipStatus.name === 'subscribe_monthly' ||
-        this.memberShipStatus.name === 'subscribe_monthly_disturb'
+        this.memberShipStatus.name === MemberType.Monthly ||
+        this.memberShipStatus.name === MemberType.MonthlyDisturbed
       )
     },
     isDisturb() {
       return (
-        this.memberShipStatus.name === 'subscribe_monthly_disturb' ||
-        this.memberShipStatus.name === 'subscribe_yearly_disturb' ||
-        this.memberShipStatus.name === 'disturb'
+        this.memberShipStatus.name === MemberType.MonthlyDisturbed ||
+        this.memberShipStatus.name === MemberType.YearlyDisturbed ||
+        this.memberShipStatus.name === MemberType.Disturbed
       )
     },
     updatePrompt() {
-      if (this.memberShipStatus.name === 'subscribe_monthly_update_to_yearly') {
+      if (this.memberShipStatus.name === MemberType.MonthlyToYearly) {
         return {
           isReadyToUpdate: true,
           updateHint: `您已成功完成年訂閱方案變更，年訂閱將於本次週期結束後生效。`,
         }
-      } else if (
-        this.memberShipStatus.name === 'subscribe_yearly_update_to_monthly'
-      ) {
+      } else if (this.memberShipStatus.name === MemberType.YearlyToMonthly) {
         return {
           isReadyToUpdate: true,
           updateHint: `您已成功完成月訂閱方案變更，月訂閱將於本次週期結束後生效。`,

--- a/constants/common.js
+++ b/constants/common.js
@@ -1,0 +1,40 @@
+/**
+ *  @readonly
+ *  @enum {string}
+ */
+const PaymentMethod = {
+  NewebPay: 'newebpay',
+  LINEPay: 'line_pay',
+  GooglePay: 'google_play',
+  AppStore: 'app_store',
+}
+
+/**
+ *  @readonly
+ *  @enum {string}
+ */
+const MemberType = {
+  YearlyDisturbed: 'subscribe_yearly_disturb',
+  MonthlyDisturbed: 'subscribe_monthly_disturb',
+  Disturbed: 'disturb',
+  MonthlyToYearly: 'subscribe_monthly_update_to_yearly',
+  YearlyToMonthly: 'subscribe_yearly_update_to_monthly',
+  Yearly: 'subscribe_yearly',
+  Monthly: 'subscribe_monthly',
+  OneTime: 'subscribe_one_time',
+  Marketing: 'marketing',
+  None: 'none',
+}
+
+/**
+ *  @readonly
+ *  @enum {string}
+ */
+const Frequency = {
+  Marketing: 'marketing',
+  Monthly: 'monthly',
+  OneTime: 'one_time',
+  Yearly: 'yearly',
+}
+
+export { PaymentMethod, MemberType, Frequency }

--- a/pages/profile/purchase.vue
+++ b/pages/profile/purchase.vue
@@ -54,6 +54,7 @@ import MemberShipStatus from '~/components/MemberShipStatus.vue'
 import MembershipPosts from '~/components/MembershipPosts.vue'
 import MembershipPayRecord from '~/components/MembershipPayRecord.vue'
 import UiMembershipUpgradeToPremium from '~/components/UiMembershipUpgradeToPremium.vue'
+import { MemberType } from '~/constants/common'
 
 export default {
   middleware: ['authenticate', 'handle-go-to-marketing'],
@@ -89,14 +90,14 @@ export default {
     isPremium() {
       const status = this.memberShipStatusName
       return (
-        status === 'subscribe_yearly' ||
-        status === 'subscribe_monthly' ||
-        status === 'disturb'
+        status === MemberType.Yearly ||
+        status === MemberType.Monthly ||
+        status === MemberType.Disturbed
       )
     },
     isBasic() {
       const status = this.memberShipStatusName
-      return status === 'subscribe_one_time'
+      return status === MemberType.OneTime
     },
     showedPostList() {
       return this.postList.slice(0, this.postMetaCount)
@@ -106,7 +107,8 @@ export default {
     },
     memberShipStatusName() {
       return (
-        this.$store.state?.['membership-subscribe']?.basicInfo?.type ?? 'none'
+        this.$store.state?.['membership-subscribe']?.basicInfo?.type ??
+        MemberType.None
       )
     },
   },

--- a/pages/subscribe/confirm.vue
+++ b/pages/subscribe/confirm.vue
@@ -92,32 +92,14 @@ export default {
       }
 
       const subscription = allSubscriptions[0]
-      const status = subscription.linePayStatus
+      const linePayStatus = subscription.linePayStatus
 
-      switch (status) {
-        case 'paying': {
-          break
-        }
-        case 'paid': {
-          // show success page even if requesting with same transactionId and orderId again
-          return {
-            status: 'success',
-            orderInfo: {
-              orderId,
-              promoteId: subscription.promoteId,
-              frequency: subscription.frequency,
-              amount: subscription.amount,
-            },
-          }
-        }
-        default: {
-          return {
-            status: 'fail',
-            errorData: {
-              message: 'linepay-fail',
-            },
-          }
-        }
+      /*
+       * Redirect to subscribe page when `linePayStatus` of the subscription is not 'paying'
+       * This behavior will be triggered when user try to load this page with the same query parameter again.
+       */
+      if (linePayStatus !== 'paying') {
+        return redirect('/subscribe')
       }
 
       // fire Confrim API request to LINE Pay Server, then push the response to PubSub

--- a/pages/subscribe/info.vue
+++ b/pages/subscribe/info.vue
@@ -317,7 +317,7 @@ export default {
       return validReceiptData
     },
     showLINEPayUI() {
-      return this.perchasedPlan?.[0]?.key === 'basic' && this.linepayUiToggle
+      return this.linepayUiToggle
     },
   },
   watch: {

--- a/utils/memberSubscription.js
+++ b/utils/memberSubscription.js
@@ -537,7 +537,7 @@ async function getMemberShipStatus(context, memberShipStatusName) {
     paymentMethod,
   } = subscription[0]
   const cardInfoLastFour = newebpayPayment?.[0] || {
-    cardInfoLastFour: null,
+    cardInfoLastFour: '',
   }
   const { maskedCreditCardNumber } = linepayPayment?.[0] || {
     maskedCreditCardNumber: null,
@@ -547,7 +547,7 @@ async function getMemberShipStatus(context, memberShipStatusName) {
       ? cardInfoLastFour
       : paymentMethod === PaymentMethod.LINEPay
       ? maskedCreditCardNumber.slice(-4)
-      : null
+      : ''
 
   const payMethodText = generatePayMethodText(paymentMethod, lastFourDigit)
 

--- a/utils/memberSubscription.js
+++ b/utils/memberSubscription.js
@@ -69,6 +69,7 @@ function formatMemberType(israfelMemberType) {
   }
 }
 
+// TODO: might not in use, should be removed
 async function getMemberDetailData(context) {
   const firebaseId = await getUserFirebaseId(context)
   if (!firebaseId) return null
@@ -118,6 +119,7 @@ async function cancelMemberSubscription(context, reason) {
   )
 }
 
+// TODO: might not in use, should be removed
 async function getMemberAllSubscriptions(firebaseId, context) {
   try {
     // get user's subscription state
@@ -508,6 +510,7 @@ async function getMemberShipStatus(context, memberShipStatusName) {
     )
     subscription = s
   } else {
+    // TODO: remove this section when LINE Pay feature is stable in production
     const {
       data: {
         member: { subscription: s },

--- a/utils/memberSubscription.js
+++ b/utils/memberSubscription.js
@@ -536,7 +536,7 @@ async function getMemberShipStatus(context, memberShipStatusName) {
     isCanceled,
     paymentMethod,
   } = subscription[0]
-  const cardInfoLastFour = newebpayPayment?.[0] || {
+  const { cardInfoLastFour } = newebpayPayment?.[0] || {
     cardInfoLastFour: '',
   }
   const { maskedCreditCardNumber } = linepayPayment?.[0] || {


### PR DESCRIPTION
1. 允許月年訂閱使用 LINE Pay 作為付款方式
2. LINE Pay 的付款結果頁在重整後，會跳轉到方案選擇頁 `/subscribe`
3. 增加常數集合，並利用它來對程式碼進行重構
4. 補上一些 request 資料上，有關 LINE Pay 資訊的遺漏
5. 增加 `TODO` 註解，作為未來處理使用