### PR TITLE
feat(index, section, category): remove article card if which contain redirect link to external site

### DIFF
--- a/components/ContainerList.vue
+++ b/components/ContainerList.vue
@@ -38,7 +38,7 @@ import MicroAd from '~/components/MicroAd.vue'
 import ContainerGptAd from '~/components/ContainerGptAd.vue'
 
 import { MICRO_AD_UNITS } from '~/constants/ads.js'
-
+import { removeArticleWithExternalLink } from '~/utils/index'
 import fetchListAndLoadmore from '~/mixins/fetch-list-and-loadmore.js'
 
 export default {
@@ -121,10 +121,16 @@ export default {
       })
     },
     listItemsInFirstPage() {
-      return this.listItemsAfterRedirect.slice(0, this.maxResults)
+      return removeArticleWithExternalLink(this.listItemsAfterRedirect).slice(
+        0,
+        this.maxResults
+      )
     },
     listItemsInLoadmorePage() {
-      return this.listItemsAfterRedirect.slice(this.maxResults, Infinity)
+      return removeArticleWithExternalLink(this.listItemsAfterRedirect).slice(
+        this.maxResults,
+        Infinity
+      )
     },
     microAdUnits() {
       return this.shouldMountMicroAds && !this.isPremiumMember

--- a/mixins/fetch-list-and-loadmore.js
+++ b/mixins/fetch-list-and-loadmore.js
@@ -100,7 +100,7 @@ export default function fetchListAndLoadmore({
           imgTextBackgroundColor: section.name && getSectionColor(section.name),
           infoTitle: item.title ?? '',
           infoDescription: stripHtmlTags(brief),
-
+          redirect: item.redirect ?? '',
           ...transformListItemContent?.call(this, item),
         }
       },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -147,6 +147,7 @@ import SvgCloseIcon from '~/assets/close-black.svg?inline'
 
 // import { isTruthy } from '~/utils/index.js'
 import { stripHtmlTags } from '~/utils/article.js'
+import { removeArticleWithExternalLink } from '~/utils/index.js'
 import { CATEGORY_ID_MARKETING, SITE_OG_IMG } from '~/constants/index.js'
 const CATEGORY_ID_POLITICAL = '5979ac0de531830d00e330a7' // 政治
 const CATEGORY_ID_CITY_NEWS = '5979ac33e531830d00e330a9' // 社會
@@ -200,6 +201,10 @@ export default {
     if (flashNewsResponse.status === 'fulfilled') {
       this.flashNews = flashNewsResponse.value || []
     }
+    this.groupedArticles.choices = removeArticleWithExternalLink(
+      this.groupedArticles.choices
+    )
+    this.getGroupedArticlesWithoutExternalLink()
 
     this.loadLatestListInitial()
   },
@@ -392,6 +397,8 @@ export default {
           'post_external01'
         )
         this.groupedArticles = groupedResponse
+        this.getGroupedArticlesWithoutExternalLink()
+
         this.loadLatestListInitial()
       }
       this.hasLoadedFirstGroupedArticle = true
@@ -434,6 +441,12 @@ export default {
       })
 
       this.areMicroAdsInserted = true
+    },
+
+    getGroupedArticlesWithoutExternalLink() {
+      this.groupedArticles.latest = removeArticleWithExternalLink(
+        this.groupedArticles.latest
+      )
     },
     async fetchFlashNews() {
       const { items: articles = [] } =
@@ -490,6 +503,7 @@ export default {
         brief,
         sections = [],
         publishedDate = '',
+        redirect = '',
       } = item
 
       return {
@@ -503,6 +517,7 @@ export default {
         label: getLabel(item),
         sectionName: item.partner ? 'external' : sections[0]?.name,
         publishedTimestamp: new Date(publishedDate).getTime(),
+        redirect,
       }
     },
     async handleInfiniteLoad(state) {
@@ -532,6 +547,7 @@ export default {
             }
           })
         )
+        this.getGroupedArticlesWithoutExternalLink()
       }
       this.pushLatestItems(
         this.groupedArticles.latest.slice(

--- a/pages/pre/story/_slug.vue
+++ b/pages/pre/story/_slug.vue
@@ -177,6 +177,8 @@ export default {
             redirectHref?.startsWith('http://')
           ) {
             this.$nuxt.context.redirect(redirectHref)
+          } else if (redirectHref?.startsWith('www.')) {
+            this.$nuxt.context.redirect(`https://${redirectHref}`)
           } else {
             this.$nuxt.context.redirect(`/pre/story/${redirectHref}`)
           }

--- a/pages/story/_slug.vue
+++ b/pages/story/_slug.vue
@@ -286,6 +286,8 @@ export default {
             redirectHref?.startsWith('http://')
           ) {
             this.$nuxt.context.redirect(redirectHref)
+          } else if (redirectHref?.startsWith('www.')) {
+            this.$nuxt.context.redirect(`https://${redirectHref}`)
           } else {
             this.$nuxt.context.redirect(`/story/${redirectHref}`)
           }

--- a/utils/index.js
+++ b/utils/index.js
@@ -20,4 +20,23 @@ function getSectionColor(name) {
   return color
 }
 
-export { isTruthy, getSectionColor }
+/**
+ * @typedef {Object} ArticleList -  an list of article info
+ * @property {string} redirect - a link to redirect other page of external site
+ */
+
+/**
+ * @param {ArticleList[]} articleList
+ * @return {ArticleList[]}
+ */
+
+function removeArticleWithExternalLink(articleList) {
+  return articleList.filter((item) => {
+    const redirectLink = item.redirect.trim()
+    return (
+      !redirectLink.startsWith('https://') &&
+      !redirectLink.startsWith('http://')
+    )
+  })
+}
+export { isTruthy, getSectionColor, removeArticleWithExternalLink }

--- a/utils/index.js
+++ b/utils/index.js
@@ -35,7 +35,8 @@ function removeArticleWithExternalLink(articleList) {
     const redirectLink = item.redirect.trim()
     return (
       !redirectLink.startsWith('https://') &&
-      !redirectLink.startsWith('http://')
+      !redirectLink.startsWith('http://') &&
+      !redirectLink.startsWith('www.')
     )
   })
 }


### PR DESCRIPTION
## Notable Change 
1. 若該post的redirect欄位不為空字串，且為外連網址（即`https://`或`http://`開頭，則從section頁、category頁、首頁中去除）。


## Commit Detail 
[08a8d6f](https://github.com/mirror-media/mirror-media-nuxt/pull/754/commits/08a8d6fd68cfc5db093e965b119734972a47acb3) : 在utils/index.js 中創立一個新的函式`removeArticleWithExternalLink()`，用於處理將具外連網址的文章從資料中移除，並引入元件`ContainerList.vue`及調整computed property `listItemsInFirstPage`與`listItemsInLoadmorePage`。


[0faa59c](https://github.com/mirror-media/mirror-media-nuxt/pull/754/commits/0faa59caa255c136d945ae2bf38d1ec493065281) : 將函式`removeArticleWithExternalLink()`引入`pages/index`，以刪除陣列`this.groupedArticle.latest`中具外連網址的文章。之所以選擇在`this.groupedArticle.latest`處理，而非`this.latestList.items`或`this.latestItems`，是因為後兩者都有被插入廣告了，但廣告的data並沒有redirect這個property，且在後兩者處理，會執行`removeArticleWithExternalLink()`更多次，所以才選擇在前者就直接處理。

## Spec 
[Asana](https://app.asana.com/0/1202642799136758/1202648905288649/f)