### PR TITLE
fix: user input lost on cancel-ask form

### DIFF
--- a/components/UiMembershipCheckoutLabel.vue
+++ b/components/UiMembershipCheckoutLabel.vue
@@ -1,10 +1,11 @@
 <template>
   <label>
     <input
-      type="checkbox"
       :id="content"
+      v-model="checked"
+      type="checkbox"
       :value="content"
-      @change="handleChange"
+      @change="$emit('handle-change')"
     />
     {{ content }}</label
   >
@@ -19,13 +20,10 @@ export default {
       default: '',
     },
   },
-  methods: {
-    handleChange(event) {
-      const isChecked = event.target.checked
-      const emitEvent = { value: event.target.value }
-      emitEvent.type = isChecked ? 'add' : 'remove'
-      this.$emit('change', emitEvent)
-    },
+  data() {
+    return {
+      checked: false,
+    }
   },
 }
 </script>


### PR DESCRIPTION
在 `cancel-ask` 中，對每個 `UiMembershipCheckoutLabel` 建立 ref，在 `cancel-ask` 這一層直接存取這些子元件的數值，
並且在使用者送出表單前，遍歷一次 option 的 array ref，取得使用者輸入的數值，確保表單正確送出使用者所填寫的內容。

註 1：option 的 array ref 是藉由在 Vue 2 時，v-for 底下對多個元件使用同樣 identifier 作為 ref 使用時，
Vue 會將其組成 array ref 的形式的 trick，這個 trick 在 Vue 3 中是被移除的，
但仍可藉由 ref 搭配 function，function 把 element 放到 array 中來手動達成。

註 2：`cancel-ask` 底下有兩個結構相同的 template，`<template v-if="!canShowFeat && doesHaveIsPayByAppValue">` 和 `<template v-if="canShowFeat && doesHaveIsPayByAppValue">`，不太清楚會有這兩個差別的原因，目前是採取移除其中一邊的方式處理，如果有問題的話會再還原 @kjwen310 

註 3：現在為 merge 和 code review 同時進行的處理模式，該 PR 發布後即會 merge，但還請協助進行 code review