### PR TITLE
feat: add `/cancel-subscription` endpoint

### DIFF
--- a/api/cancel-subscription.js
+++ b/api/cancel-subscription.js
@@ -1,0 +1,191 @@
+import express from 'express'
+import errors from '@twreporter/errors'
+import { ISRAFEL_ORIGIN } from '../configs/config.js'
+import requestAuthentication from '../serverMiddleware/requestAuthentication.js'
+import { STATUS as REQUEST_STATUS } from '../constants/request.js'
+import { PaymentMethod } from '../constants/common.js'
+import { fireGqlRequest, linepayClient, sendResponse } from './helpers'
+
+/**
+ *  @typedef {import('express').Request} Request
+ *  @typedef {import('express').Response} Response
+ */
+
+const apiUrl = `${ISRAFEL_ORIGIN}/api/graphql`
+
+const app = express()
+app.use(requestAuthentication())
+
+/**
+ *  API endpoint for cancelling member's subscription
+ *
+ *  @param {Request} req
+ *  @param {Response} res
+ *  @return {void}
+ */
+app.post('/', async (req, res) => {
+  try {
+    // check query parameters
+    const { firebaseId, note } = req.body
+
+    if (!firebaseId) {
+      return sendResponse({
+        status: REQUEST_STATUS.FAIL,
+        data: {
+          title: `Missing query parameter.`,
+        },
+        res,
+      })
+    }
+
+    // retrieve subscription data from back-end
+    const fetchRecurringSubscription = `
+      query ($firebaseId: String!) { 
+        member(where: { firebaseId: $firebaseId }) {
+          email
+          type
+          subscriptions: subscription(
+            first: 1
+            where: { frequency_in: [yearly, monthly], isActive: true }
+            orderBy: { periodEndDatetime: desc }
+          ) {
+            id
+            isCanceled
+            frequency
+            nextFrequency
+            orderNumber
+            paymentMethod
+            linepayPaymentInfo {
+              id
+              regKey
+            }
+          }
+        }
+      }
+    `
+
+    const {
+      data: {
+        member: { subscriptions },
+      },
+    } = await fireGqlRequest(
+      fetchRecurringSubscription,
+      {
+        firebaseId,
+      },
+      apiUrl
+    )
+
+    const subscription = subscriptions[0]
+
+    if (!subscription) {
+      return sendResponse({
+        status: REQUEST_STATUS.FAIL,
+        data: {
+          title: `No valid subscription record`,
+        },
+        res,
+      })
+    }
+
+    // LINE Pay related handle
+
+    const { linepayPaymentInfo } = subscription
+    if (
+      subscription.paymentMethod === PaymentMethod.LINEPay &&
+      linepayPaymentInfo
+    ) {
+      const { id, regKey } = linepayPaymentInfo
+
+      // call Expire RegKey API to make regKey expired
+      try {
+        await linepayClient.expireRegKey.send({
+          regKey,
+        })
+      } catch (err) {
+        const returnCode = err.data?.returnCode
+
+        // unexpected error
+        if (!returnCode) {
+          throw err
+        }
+      }
+
+      // set `isExpired` in linepayPaymentInfo to 'true'
+      const expireKey = `
+        mutation ($id: ID!) {
+          updatelinepayPaymentInfo(id: $id, data: { isExpired: true }) {
+            id
+            regKey
+            isExpired
+          }
+        }
+      `
+
+      await fireGqlRequest(
+        expireKey,
+        {
+          id,
+        },
+        apiUrl
+      )
+    }
+
+    // change subscription.isCanceled to true (carry unsubscribe reason)
+    const unsubscribe = ` 
+      mutation ($id: ID!, $note: String) {
+        updatesubscription(id: $id, data: { isCanceled: true, note: $note }) {
+          id
+          frequency
+          isActive
+          isCanceled
+          note
+        }
+      }
+    `
+
+    const result = await fireGqlRequest(
+      unsubscribe,
+      {
+        id: subscription.id,
+        note,
+      },
+      apiUrl
+    )
+
+    sendResponse({
+      status: REQUEST_STATUS.SUCCESS,
+      data: {
+        title: 'Succeed in cancelling subscription.',
+        data: result.data?.updatesubscription,
+      },
+      res,
+    })
+  } catch (error) {
+    const annotatingError = errors.helpers.wrap(
+      error,
+      'api/cancel-subscription',
+      'Encounter error on cancelling subscription'
+    )
+
+    // eslint-disable-next-line no-console
+    console.error(
+      JSON.stringify({
+        severity: 'ERROR',
+        message: errors.helpers.printAll(annotatingError, {
+          withStack: true,
+          withPayload: true,
+        }),
+      })
+    )
+
+    sendResponse({
+      status: REQUEST_STATUS.ERROR,
+      message: 'Encounter error on cancelling subscription.',
+      code: 500,
+      res,
+    })
+  }
+})
+
+module.exports = app

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -304,6 +304,10 @@ module.exports = {
       handler: '~/api/linepay.js',
     },
     {
+      path: `/${API_PATH_FRONTEND}/cancel-subscription/v1`,
+      handler: '~/api/cancel-subscription.js',
+    },
+    {
       path: `/${API_PATH_FRONTEND}/papermag/v1`,
       handler: '~/api/papermag.js',
     },

--- a/plugins/requests/index.js
+++ b/plugins/requests/index.js
@@ -3,6 +3,8 @@ import _ from 'lodash'
 import axios from 'axios'
 import qs from 'qs'
 import {
+  getUserFirebaseId,
+  getFirebaseToken,
   getMemberDetailData,
   getMemberServiceRuleStatus,
   setMemberServiceRuleStatusToTrue,
@@ -397,5 +399,11 @@ export default (context, inject) => {
   })
   inject('isMemberPaidSubscriptionWithMobile', async () => {
     return await isMemberPaidSubscriptionWithMobile(context)
+  })
+  inject('getUserFirebaseId', () => {
+    return getUserFirebaseId(context)
+  })
+  inject('getFirebaseToken', () => {
+    return getFirebaseToken(context)
   })
 }

--- a/utils/memberSubscription.js
+++ b/utils/memberSubscription.js
@@ -674,6 +674,8 @@ async function updateSubscriptionFromMonthToYear(context, subscriptionId) {
 }
 
 export {
+  getUserFirebaseId,
+  getFirebaseToken,
   getMemberDetailData,
   getMemberServiceRuleStatus,
   setMemberServiceRuleStatusToTrue,

--- a/utils/memberSubscription.js
+++ b/utils/memberSubscription.js
@@ -92,6 +92,8 @@ async function getMemberDetailData(context) {
 }
 
 async function cancelMemberSubscription(context, reason) {
+  // TODO: remove this function when LINE Pay feature is stable in production
+
   const firebaseId = await getUserFirebaseId(context)
   if (!firebaseId) return null
 


### PR DESCRIPTION
https://github.com/mirror-media/mirror-media-nuxt/commit/f2afe34548e6db721c52a0d7add8edbce84cf155
* 將 [utils/membership](https://github.com/mirror-media/mirror-media-nuxt/compare/dev...erase2004:mirror-media-nuxt:dev#diff-e4197d07da7970f2c4dd68009b797e6020e8c030bb8821b2bad8dabdffe2017d) 中的 `getUserFirebaseId` 和 `getFirebaseToken` inject 到前端的 this 中。

https://github.com/mirror-media/mirror-media-nuxt/commit/428a2155b12d49ed70d389fbdb05af3cc2f09b37
* 增加一個專門用來處理訂閱取消的 API endpoint，在藍新的流程中，只有對 DB 中 subscription 的數值進行更動；
但在 LINE Pay 的流程中，會對 regKey 使用 Expire RegKey API，讓 regKey 失效，
然後再對 DB 中的 regKey 與 subscription 的數值進行更新。

註 1：現在為 merge 和 code review 同時進行的處理模式，該 PR 發布後即會 merge，但還請協助進行 code review