### PR TITLE
fix: unexpected subscription stopped when user upgraded from month to year after cancelling subscription

### DIFF
--- a/apollo/mutations/memberSubscriptionMutation.gql
+++ b/apollo/mutations/memberSubscriptionMutation.gql
@@ -17,12 +17,13 @@ mutation unsubscribe($id: ID!, $note: String) {
   }
 }
 
-mutation setSubscriptionFromMonthToYear($id: ID!) {
-  updatesubscription(id: $id, data: { nextFrequency: yearly }) {
+mutation setSubscriptionFromMonthToYear($id: ID!, $changeDate: String!) {
+  updatesubscription(id: $id, data: { nextFrequency: yearly, isCanceled: false, changePlanDatetime: $changeDate }) {
     orderNumber
     id
     frequency
     nextFrequency
+    changePlanDatetime
     isActive
     isCanceled
     note

--- a/utils/memberSubscription.js
+++ b/utils/memberSubscription.js
@@ -665,11 +665,14 @@ async function updateSubscriptionFromMonthToYear(context, subscriptionId) {
   const firebaseId = await getUserFirebaseId(context)
   if (!firebaseId) return null
 
+  const changeDate = new Date().toISOString()
+
   // get user's subscription state
   return await fireGqlRequest(
     setSubscriptionFromMonthToYear,
     {
       id: subscriptionId,
+      changeDate,
     },
     context
   )


### PR DESCRIPTION
修正使用者在取消訂閱後，在當期訂閱結束前，進行月升年訂閱的操作，而在下一期扣款時，訂閱依舊停止的錯誤。
調整 `setSubscriptionFromMonthToYear` ，讓使用者在進行月生年訂閱操作時，讓 `isCanceled` 欄位設為 false，
使得訂閱可以在下一期扣款時被處理。
另外，也補上使用者月升年操作的時間資訊。

註 1：現在為 merge 和 code review 同時進行的處理模式，該 PR 發布後即會 merge，但還請協助進行 code review