### PR TITLE
fix(story): render  AD `PC_FLOATING` by `v-if` rather than `v-show`

### DIFF
--- a/pages/__tests__/story.spec.js
+++ b/pages/__tests__/story.spec.js
@@ -154,7 +154,7 @@ describe('AD', () => {
     expect(wrapper.find('.dable-widget').exists()).toBe(false)
     expect(wrapper.findComponent(UiStickyAd).exists()).toBe(false)
     expect(wrapper.findComponent(ContainerFullScreenAds).exists()).toBe(false)
-    expect(wrapper.get('.ad-pc-floating').isVisible()).toBe(false)
+    expect(wrapper.find('.ad-pc-floating').exists()).toBe(false)
   })
 
   test('do not show ADs of MB_ST, MB_FS, MB_AD2 & MB_INNITY when a story has the wine category name', () => {

--- a/pages/story/_slug.vue
+++ b/pages/story/_slug.vue
@@ -166,7 +166,7 @@
 
           <UiAdultContentWarning v-if="story.isAdult" />
 
-          <div v-show="shouldShowAdPcFloating" class="ad-pc-floating">
+          <div v-if="shouldShowAdPcFloating" class="ad-pc-floating">
             <ContainerGptAd
               :pageKey="sectionCarandwatchId"
               adKey="PC_FLOATING"


### PR DESCRIPTION
If we use `v-show` to render advertisement, Vue will always render it, but add inline style css `display: none` on DOM as a condition of rendering, which cause the problem that the page view of advertisement will increase imprecisely, since which has been render and count into page view, but not been seen by user.
To fix this problem, we decide to change the conditional rendering by `v-if`, despite some loss of web performance is required.