### PR TITLE
fix: remove unnessary event handle

### DIFF
--- a/pages/subscribe/cancel-ask.vue
+++ b/pages/subscribe/cancel-ask.vue
@@ -30,21 +30,9 @@
         <p class="cancel-ask__description">
           請問您為何想取消訂閱鏡週刊 Premium 服務？
         </p>
-        <UiMembershipCheckoutLabel
-          ref="option"
-          content="文章無法滿足需求"
-          @handle-change="updateReason"
-        />
-        <UiMembershipCheckoutLabel
-          ref="option"
-          content="已訂閱其他媒體"
-          @handle-change="updateReason"
-        />
-        <UiMembershipCheckoutLabel
-          ref="option"
-          content="使用體驗不佳"
-          @handle-change="updateReason"
-        />
+        <UiMembershipCheckoutLabel ref="option" content="文章無法滿足需求" />
+        <UiMembershipCheckoutLabel ref="option" content="已訂閱其他媒體" />
+        <UiMembershipCheckoutLabel ref="option" content="使用體驗不佳" />
         <UiMembershipCheckoutLabel
           ref="option"
           content="想改用單篇付費方式繼續閱讀"


### PR DESCRIPTION
https://github.com/mirror-media/mirror-media-nuxt/pull/757#pullrequestreview-1083456549
依照這裡回報的問題進行修正。

因為在表單送出時，會使用 array ref 來遍歷元素取得最終的數值，所以其實除了 **其他** 選項在開啟輸入框部份的需求外，
其他元素其實不用處理 `handle-change` 的 event，因此將其移除，減少這部份多餘的計算。