### PR TITLE
feat(ContainerStoryBody): add mirrormedia logo in front of share icon

### DIFF
--- a/components/ContainerStoryBody.vue
+++ b/components/ContainerStoryBody.vue
@@ -17,6 +17,12 @@
     <div v-if="credit" class="story__credit" v-html="credit"></div>
 
     <div class="story__share">
+      <img
+        src="../assets/logo@2x.png"
+        alt="Mirror Media"
+        class="story__share--logo"
+      />
+      <div class="story__share--br" />
       <UiShareFb />
       <UiShareLine />
     </div>
@@ -546,6 +552,7 @@ export {
   &__share {
     display: flex;
     margin-bottom: 45px;
+    align-items: center;
 
     a {
       width: 35px;
@@ -553,6 +560,18 @@ export {
       + a {
         margin-left: 10px;
       }
+    }
+
+    &--br {
+      margin: 0 20px;
+      width: 1px;
+      height: 16px;
+      background: #a1a1a1;
+    }
+
+    &--logo {
+      width: 35px;
+      display: flex;
     }
   }
 

--- a/components/ContainerStoryBody.vue
+++ b/components/ContainerStoryBody.vue
@@ -16,13 +16,9 @@
     <!-- eslint-disable-next-line vue/no-v-html -->
     <div v-if="credit" class="story__credit" v-html="credit"></div>
 
-    <div class="story__share">
-      <img
-        src="../assets/logo@2x.png"
-        alt="Mirror Media"
-        class="story__share--logo"
-      />
-      <div class="story__share--br" />
+    <div class="story__share share">
+      <img src="../assets/logo@2x.png" alt="Mirror Media" class="share__logo" />
+      <br class="share__br" />
       <UiShareFb />
       <UiShareLine />
     </div>
@@ -562,14 +558,16 @@ export {
       }
     }
 
-    &--br {
+    .share__br {
+      content: '';
+      display: block;
       margin: 0 20px;
       width: 1px;
       height: 16px;
       background: #a1a1a1;
     }
 
-    &--logo {
+    .share__logo {
       width: 35px;
       display: flex;
     }


### PR DESCRIPTION
### 描述
- 新增週刊 logo 在文章前分享按鈕區。
- 和分享按鈕中間的分隔線不用 after 是為了方便之後重複使用。

### 參考資料
- [Asana 卡片](https://app.asana.com/0/1202818785594571/1202828022375648)
- [figma 設計稿](https://www.figma.com/file/qmocxMBHG6D7T2VPdydRWG/%E9%8F%A1%E9%80%B1%E5%88%8A---%E7%B6%B2%E7%AB%99?node-id=7528%3A19144)