### PR TITLE
fix: wrong fallback value causes error

### DIFF
--- a/utils/memberSubscription.js
+++ b/utils/memberSubscription.js
@@ -623,7 +623,7 @@ async function getMemberShipStatus(context, memberShipStatusName) {
     cardInfoLastFour: '',
   }
   const { maskedCreditCardNumber } = linepayPayment?.[0] || {
-    maskedCreditCardNumber: null,
+    maskedCreditCardNumber: '',
   }
   const lastFourDigit =
     paymentMethod === PaymentMethod.NewebPay


### PR DESCRIPTION
修正錯誤的 fallback value，導致在 Ln. 628-633 處理 `lastFourDigit` 資訊時，意外拋出 error，近而使得在 `/profile/purchase` 頁面，無法正確顯示 LINE Pay 相關付款紀錄的問題。