### PR TITLE
fix: duplicated Confirm API request cause error on subscription result

### DIFF
--- a/constants/linepay.js
+++ b/constants/linepay.js
@@ -1,0 +1,6 @@
+const RETURN_CODE = {
+  SUCCESS: '0000',
+  ORDER_NUMBER_DUPLICATED: '1172',
+}
+
+export { RETURN_CODE }


### PR DESCRIPTION
### 類型：
修正問題
### 問題敘述：
在 LINEPay 付款結果頁，因為在 `asyncData` 下進行重複的 Confirm API 呼叫，產生兩筆呼叫結果寫入到 PubSub，
其中一筆為 Success，另一筆為 Same Order Id，又 PubSub  本身不保證訊息遞送的順序，
因此在 subscriber 接收處理時，先處理了 Same Order Id 的結果，導致後來的 Success 的結果無法寫入，
於是 Subscription 的交易結果狀態為錯誤的 `fail`
### 解決方式：
限定 `asyncData` 僅在 server side 執行，並且當 Confirm API 呼叫結果為 Same Order Id 的情況下，直接中斷後續執行，避免寫入到 PubSub