### PR TITLE
fix(ContainerCulturePost): missing post.id data

### DIFF
--- a/components/culture-post/ContainerCulturePost.vue
+++ b/components/culture-post/ContainerCulturePost.vue
@@ -115,6 +115,10 @@ export default {
       type: Number,
       default: 0,
     },
+    shouldShwowAd: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   data() {
@@ -135,6 +139,7 @@ export default {
     }),
     post() {
       const {
+        id = '',
         title = '',
         brief = {},
         writers = [],
@@ -159,6 +164,7 @@ export default {
       const ogImgsResized = ogImage?.image?.resizedTargets || {}
 
       return {
+        id,
         title,
         credits: getCredits(),
         brief: getBrief(),


### PR DESCRIPTION
因為 post id 遺失，導致使用者在這種頁面的文章中，進行單篇購買時，沒有文章 id 資訊

關聯任務：[debug line pay單篇有時無法寫入文章ID](https://app.asana.com/0/1202984858902501/1203019334697133/f)