### PR TITLE
fix(UiEmbeddedCode): unable show photo of multiple instagram embed code

### DIFF
--- a/components/UiEmbeddedCode.vue
+++ b/components/UiEmbeddedCode.vue
@@ -1,9 +1,10 @@
 <template>
   <div>
     <div ref="embeddedcode" />
-    <LazyRenderer @load="insertScriptsInBody(embeddedCode)">
+    <LazyRenderer v-if="!isInstagram" @load="insertScriptsInBody(embeddedCode)">
       <p v-if="caption" class="caption">{{ caption }}</p>
     </LazyRenderer>
+    <p v-if="caption && isInstagram" class="caption">{{ caption }}</p>
   </div>
 </template>
 
@@ -25,7 +26,17 @@ export default {
     embeddedCode() {
       return this.content?.embeddedCode ?? ''
     },
+    isInstagram() {
+      return this.embeddedCode?.includes('instagram-media')
+    },
   },
+
+  mounted() {
+    if (this.isInstagram) {
+      this.insertScriptsInBody(this.embeddedCode)
+    }
+  },
+
   methods: {
     insertScriptsInBody(embeddedCode) {
       const fragment = document.createDocumentFragment()


### PR DESCRIPTION
# 問題描述: 當頁面有多個Instagram Embed Code時，部分Embed Code無法顯示圖片

> 順手紀錄一下debug的過程


## TL;DR
只要Instagram任一embed code載入後，就會fetch所有IG embed code所需要的圖片，但我們所使用的套件LazyRenderer只會掛載在viewport內的embed code，所以IG fetch時無法找到未被掛載的的embed code，導致錯誤。



## 問題發生時機：
只要兩個Instagram(下文簡稱IG) embed code相距過長，會導致不在一屏內的embed code無法正確載入。


## 問題解法
本篇將介紹IG embed code的結構，並展示embed code如何拿到圖片並render的過程，進而提出造成bug的原因，以及目前的解法。
由於IG並沒有開源embed code的相關程式碼，request拿到的js file 都是uglify過的，所以本篇含大量觀察與猜測，不一定正確。


### Structure of IG embed code
首先先展示embed code結構，並說明IG embed code從embed 到render圖片的過程。

我們在IG拿到的embed code結構長這樣，
```javascript=
<blockquote class="instagram-media">...</blockquote>
<script async src="//www.instagram.com/embed.js"></script>
```
分成兩部分，`<blockquote>`跟`<script>`：
`<blockquote></blockquote>`如果render在前端會是一個沒有圖片的IG框框，長這樣

![localhost_3000_story_test-ig-embed-less_](https://user-images.githubusercontent.com/85677992/198227755-b1c78591-e097-4bb4-a441-cabd2da45d2d.png)

`<script>`則會做三件事情：
1. 打IG的API，拿到ig的js file
2. 把blockquote去掉，改為一個有圖片的`<ifame></ifame>`：

```
<iframe class="instagram-media instagram-media-rendered" id="instagram-embed-0" src="...">...</iframe>
<script async src="//www.instagram.com/embed.js"></script>
```
![localhost_3000_story_test-ig-embed_](https://user-images.githubusercontent.com/85677992/198228275-abe90258-8832-477c-9e4f-fbf9a2236aa2.png)

> Shiba is cute

而去掉`<blockquote>`並改換成`<iframe>`的過程如下：

- 加入`<iframe>`，此時iframe與`<blockquote></blockquote>`共存
```javascript=
<iframe></iframe>
<blockquote class="instagram-media">...</blockquote>
<script async src="//www.instagram.com/embed.js"></script>
```
- 修改`<blockquote>`的class name，變為 `class="instagram-media-registered"`
- 刪除`<blockquote>`


### What does `<script>` do ?
說明了embed code的結構與變化過程後，接下來將深入探討`<script async src="//www.instagram.com/embed.js"></script>`做了什麼事情。

> 由於broswer發request拿到的js file 都是被uglify過的，所以我使用Google Chrome devtool 的「Network request blocking」功能，並比較不同request被block後的差異。

首先，每個IG embed code都有這段`<script async src="//www.instagram.com/embed.js"></script>`，但在正常情況下，不論頁面中有多少個IG embed code，`一個頁面只會執行該<script>` **一次**。
而這個`<script>`會302 redirect，並發request 給`https://www.instagram.com/static/bundles/es6/EmbedSDK.js/ab12745d93c5.js`。

等拿到response後，`ab12745d93c5.js`會幫我們做兩件事情：
1. 在每一個IG embed code的`<blockquote>`上方插入一個`<iframe>`，並加入attribute `id="instagram-embed-${index}"`（如果頁面有多個IG embed code，每個embed code的iframe都有unique的id，比如說`id="instagram-embed-0"`、`id="instagram-embed-1"`...）。
3. 修改blockquote的class name，變為 `class="instagram-media-registered"`
4. 拿到每個embed code的iframe的圖片
但此時，iframe並不會顯示圖片。

接下來，每一個embed code會**馬上**發一個request，endpoint為
`https://www.instagram.com/static/bundles/es6/EmbedSimple.js/f412930974f3.js`
（所以如果有五個embed code就會發五個request)

拿到response後，`f412930974f3.js`會做兩件事情：
1. 刪除`<blockquote>`
 > 我猜是只有class name為instgram-media-registered才會被刪除
2. 顯示圖片

當然還有其他的request，但經歷上述過程後，IG embed code已經可以正常顯示圖片了。


### Cause of the Problem
那回到正題，我們的問題出在哪，才造成多則IG會無法正常顯示圖片？
出在我們使用的套件[LazyRenderer](https://github.com/yeefun/vue-lazy-renderer)。

這個套件有一個emit function `@load`，用途是當元件進入viewport時，執行特定的function。而在UiEmbeddedCode.vue中，我們執行的特定function為`insertScriptsInBody`，簡單來說就是插入embed code。所以當某個IG embeded code不在viewport中，就不會插入該IG embeded code的`<blockquote>`與`<script>`。

所以bug是這樣發生的：
1. 假設我們的文章很長，然後文章開頭跟結尾各有一個embed code，分別為embed code A與 embed code B。
2. 使用者進入文章開頭，看到了A，LazyRenderer幫我們插入A的`<blockquote>`與`<script>`。
3. A的`<script async src="//www.instagram.com/embed.js"></script>`會執行，並把頁面裡面**每個**`blockquote`上方加上`iframe`，以及修改`blockquote`的class name。
5. 但由於LazyRenderer的緣故，所以B目前並**不存在DOM元素中**，A所執行的的script不知道有B的存在，自然不會幫**B加上iframe**，也不會取得B所需要的圖片。
6. 此時也只有A會發後續的request`f412930974f3.js`，並顯示圖片。
7. 當我們滑到B時，B也會加上`<script async src="//www.instagram.com/embed.js"></script>`並發request，但此時卻不會拿到B的圖片，也不會幫B加上iframe。B也不會發後續的request（這邊原因不明）。



### Solution
目前的解法是參照[readr-nuxt](https://github.com/readr-media/readr-nuxt/blob/dev/components/shared/RdEmbeddedCode.vue#L36-L39)的做法: 如果是IG embed code，則不透過套件LazyRenderer載入embed code，而是在vue life cycle `mounted()`中載入
