### PR TITLE
fix(topic): unable update `tags` even when cms is updated

### DIFF
--- a/deprecated/topic-page/Topic.vue
+++ b/deprecated/topic-page/Topic.vue
@@ -458,9 +458,25 @@ export default {
       )
       this.concatArticleList()
     }
+
+    /**
+     * function of computing variable `metaTopicKeywords`
+     * see comment at `metaTopicKeywords` to realize why use $fetchTopic and $fetchTags is needed.
+     * @type {{tags: string[]| [] }}}
+     */
+    const data = await this.$fetchTopic(this.$route.params.topicId)
+    if (data?.tags?.length !== 0) {
+      const tagsRes = await this.$fetchTags({
+        id: data?.tags,
+      })
+
+      this.tagsName = tagsRes.items.map((i) => i.name)
+    }
   },
   data() {
     return {
+      tagsName: [],
+
       // data for new feature
       pageOfNotFeaturedArticle: 1,
       pageOfIsFeaturedArticle: 1,
@@ -770,10 +786,17 @@ export default {
       return SITE_DESCRIPTION
     },
 
-    // we transform array `this.tags` to string, and assign it as content of meta `keywords`
+    /*
+     * Originally, we use computed variable `this.tags`and transform it to string, then assign it as content of meta `keywords`.
+     * However, some bug is happened at unknown situation:
+     * `this.tag` will not be updated to the status of cms at unknown situation.
+     * Because the structure of code at Topic page is too complex and hard to refactor, we not to trace root case, but rewrite another logic of getting tags:
+     * we use function `this.$fetchTopic` to get id of tags which certain topic page contain, and use function `this.$fetchTags` to get name of tags.
+     * After we get name of tags, we transform it to string, then assign it as content of meta `keywords`..
+     */
     metaTopicKeywords() {
-      if (Array.isArray(this.tags) && this.tags.length !== 0) {
-        return this.tags.map((tag) => tag.name).join(', ')
+      if (Array.isArray(this.tagsName) && this.tagsName.length !== 0) {
+        return this.tagsName.join(', ')
       }
       return undefined
     },

--- a/plugins/requests/index.js
+++ b/plugins/requests/index.js
@@ -71,7 +71,8 @@ async function fetchApiData(url, fromMembershipGateway = false, token) {
     data.items?.length > 0 ||
     Object.keys(data.endpoints || {}).length > 0 ||
     data.hits?.total?.value > 0 || // properties response by /search api
-    (url.startsWith('/tags') && data.id)
+    (url.startsWith('/tags') && data.id) ||
+    (url.startsWith('/topics') && data.id)
 
   if (hasData) {
     return fromMembershipGateway
@@ -294,12 +295,14 @@ export default (context, inject) => {
   )
 
   inject('fetchTag', (id) => fetchApiData(`/tags/${id}`))
+  inject('fetchTags', (params) => fetchApiData(`/tags${buildParams(params)}`))
 
   inject('fetchTimeline', (id) => fetchApiData(`/timeline/${id}`))
 
   inject('fetchTopics', (params) =>
     fetchApiData(`/topics${buildParams(params)}`)
   )
+  inject('fetchTopic', (id) => fetchApiData(`/topics/${id}`))
 
   inject('fetchWatches', (params) =>
     fetchApiData(`/watches${buildParams(params)}`)


### PR DESCRIPTION
原本使用變數`this.tags`生成computed variable `metaTopicKeywords`，並將其指派為位於head的meta tag `keywords`。
但因為未知的原因，導致cms的標籤欄位更新後，`this.tags`卻無法同步更新。
由於topic頁code十分複雜，含有大量資料處理的函式，打的api也與其他頁不同，且未來並無重構的計畫（而是直接重寫），
所以目前決定不trace root cause，而是直接打其他api，以取得meta tag `keywords`所需要的資料。

詳細實作過程，請見程式碼註解。