### PR TITLE
fix: random wrong order-fail page

### DIFF
--- a/pages/papermag/return/index.vue
+++ b/pages/papermag/return/index.vue
@@ -37,13 +37,11 @@ export default {
     SubscribeFail,
     SubscribeSuccess,
   },
-  async asyncData({ req, redirect, route }) {
-    if (route.query['order-fail'])
+  async asyncData({ req, redirect }) {
+    if (!req) {
       return {
         status: 'order-fail',
       }
-    if (req.method !== 'POST') {
-      redirect('/papermag')
     }
 
     const trace = req.header('X-Cloud-Trace-Context')?.split('/')
@@ -57,6 +55,17 @@ export default {
         'logging.googleapis.com/trace': `projects/mirrormedia-1470651750304/traces/${trace}`,
       })
     )
+
+    if (req.method !== 'POST') {
+      redirect('/papermag')
+      return
+    }
+
+    if (Object.prototype.hasOwnProperty.call(req.query, 'order-fail')) {
+      return {
+        status: 'order-fail',
+      }
+    }
 
     try {
       const infoData = req.body


### PR DESCRIPTION
無法明確推測出實際導致紙本訂閱 (`P2210230249`)，在完成付款後，卻在付款結果頁顯示為交易失敗的問題，

檢視了以下的 Cloud Logging 紀錄，發現 19:47 左右的那一筆，也就是本次的 249，
沒有 asyncData 中的 `console.log`，但後面的 API tracking 紀錄又顯示使用者是在交易結果頁，
且頁面為交易失敗的內容，於是，推測直接執行了顯示交易失敗結果的邏輯。

目前把 log 的時間往前提，放便遇到類似情況時的除錯。

ref:
[Cloud Logging 1](https://console.cloud.google.com/logs/query;query=%22219.68.181.218%22;timeRange=2022-10-23T11:46:00.000Z%2F2022-10-23T11:46:00.000Z--PT1H;cursorTimestamp=2022-10-23T11:51:02.663332319Z?referrer=search&project=mirrormedia-1470651750304)

[Cloud Logging 2](https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22mirrormedia-1470651750304%22%0Aresource.labels.location%3D%22asia-east1-a%22%0Aresource.labels.cluster_name%3D%22mirrormedia-production%22%0Aresource.labels.namespace_name%3D%22default%22%0Alabels.k8s-pod%2Fapp%3D%22mirror-media-nuxt%22%0Alabels.k8s-pod%2Fapp_kubernetes_io%2Finstance%3D%22mirror-media-nuxt%22%0Alabels.k8s-pod%2Fapp_kubernetes_io%2Fname%3D%22mirror-media-nuxt%22%0Alabels.k8s-pod%2Ftier%3D%22frontend%22%20severity%3E%3DDEFAULT%0A%22%2Fpapermag%2Freturn%22;timeRange=2022-10-23T11:41:00.000Z%2F2022-10-23T11:55:00.000Z;cursorTimestamp=2022-10-23T11:51:01.220983146Z?project=mirrormedia-1470651750304&pli=1)

[Cloud Logging 3](https://console.cloud.google.com/logs/query;query=resource.type%20%3D%20%22cloud_run_revision%22%0Aresource.labels.service_name%20%3D%20%22mm-subscription-webhooks-publishers%22%0Aresource.labels.location%20%3D%20%22asia-east1%22%0A%20severity%3E%3DDEFAULT;timeRange=2022-10-23T11:41:00.000Z%2F2022-10-23T11:55:00.000Z;cursorTimestamp=2022-10-23T11:50:59.111694Z?project=mirrormedia-1470651750304)