### PR TITLE
fix: firebase login fails on Safari 16.0+ version

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -389,7 +389,7 @@ module.exports = {
             default: {
               return {
                 apiKey: 'AIzaSyAavk46-8OQ4B2cv0TOqxOMjd5Fe4tIauc',
-                authDomain: 'mirrormediaapptest.firebaseapp.com',
+                authDomain: 'dev.mirrormedia.mg',
                 databaseURL: 'https://mirrormediaapptest.firebaseio.com',
                 projectId: 'mirrormediaapptest',
                 storageBucket: 'mirrormediaapptest.appspot.com',


### PR DESCRIPTION
This patch tries to fix firebase login problem.
We do not know if this patch change fixes the problem
or not. We have to merge this commit into dev environment
and test it afterwards.

The related issue is
https://github.com/firebase/firebase-js-sdk/issues/6716

In short, the root cause is cross-origin storage access.
Therefore, this patch updates firebase config `authDomain`.

### Asana
https://app.asana.com/0/1203478225444487/1203539528339316/f