### PR TITLE
feat: add /externals/warnlife

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ To avoid unpredictable error occur when developing, please use Classic Stable ve
 | SEARCH_URL                        | 字串             | 'search-url/search'                          | 搜尋頁面 url                                                                  |
 | MEMBER_ARTICLE_HISTORY_MAX_AGE    | 字串             | '30'                                         | 會員訂閱前閱覽紀錄有效期限，以分鐘為單位                                      |
 | DONATION_PAGE_URL                 | 字串             | undefined                                    | 捐款頁網址（目前捐款頁為外部頁面，使用 `/donate` 作為 proxy ）                |
-| WARN_LIFE_FEATURE_TOGGLE          | 布林值           | false                                        | 用 'on' 啟用的數值 ...                                                        |
+| WARM_LIFE_FEATURE_TOGGLE          | 布林值           | false                                        | 用 'on' 啟用的數值 ...                                                        |
 
 ## Feature Toggle
 

--- a/README.md
+++ b/README.md
@@ -22,49 +22,53 @@ $ yarn generate
 For detailed explanation on how things work, check out [Nuxt.js docs](https://nuxtjs.org).
 
 ## Yarn version
-因為v2、v3的yarn版本，在執行 `yarn dev` `yarn build` 時，會跳出許多錯誤，
-所以目前本專案仍採用classic stable version。
-截至2022.4.28，最新的classic stable version 為1.22.18，開發時請使用~1.22.0的版本。
+
+因為 v2、v3 的 yarn 版本，在執行 `yarn dev` `yarn build` 時，會跳出許多錯誤，
+所以目前本專案仍採用 classic stable version。
+截至 2022.4.28，最新的 classic stable version 為 1.22.18，開發時請使用~1.22.0 的版本。
 To avoid unpredictable error occur when developing, please use Classic Stable version of yarn(~1.22.0).
 
 ## Environment Variables
-| 變數名稱 | 資料型態 | 初始值 | 變數說明 |
-| --- | --- | --- | --- |
-| ENV | 字串 | 'local' | 系統環境，目前已知有；`local`、`dev`、`staging`、`production` 和 `lighthouse` |
-| REDIS_READ_HOST | 字串 | 'redis-read-host' | 讀取用的 Redis hostname or ip |
-| REDIS_WRITE_HOST | 字串 | 'redis-write-host' | 寫入用的 Redis hostname or ip |
-| REDIS_AUTH | 字串 | 'redis-auth' | Reids 驗證用資訊 |
-| NEWEBPAY_KEY | 長度為 32 的字串 | 'newebpay-key' | 藍新支付 API key (Premium 訂閱) |
-| NEWEBPAY_IV | 長度為 16 的字串 | 'newebpay-iv' | 藍新支付 API iv (Premium 訂閱) |
-| NEWEBPAY_MEMBERSHIP_API_URL | 字串 | 'https://ccore.newebpay.com/MPG/mpg_gateway' | 藍新支付 API URL (Premium 訂閱) |
-| NEWEBPAY_PAPERMAG_KEY | 字串 | 'newebpay-papermag-key' | 藍新支付 API key (紙本雜誌) |
-| NEWEBPAY_PAPERMAG_IV | 字串 | 'newebpay-papermag-iv' | 藍新支付 API iv (紙本雜誌) |
-| NEWEBPAY_PAPERMAG_API_URL | 字串 | 'https://ccore.newebpay.com/MPG/mpg_gateway' | 藍新支付 API URL (紙本雜誌) |
-| ISRAFEL_ORIGIN | 字串 | 'israfel-origin' | Israfel URL |
-| API_HOST | 字串 | 'api-host' | API GATEWAY URL |
-| API_HOST_MEMBERSHIP_GATEWAY | 字串 | 'api-host-membership-gateway' | API GATEWAY URL |
-| API_MEMBER_SUBSCRIPTION_GATEWAY | 字串 | 'api-member-subscription-gateway' | API GATEWAY URL |
-| IS_AD_DISABLE | 布林值 | false | | |
-| PREMIUM_AD_FEATURE_TOGGLE | 布林值 | false | 用 'on' 啟用的數值 ... |
-| ENABLE_CLOUD_LOGGING | 布林值 | false | 開啟 gcloud/logging 行為 |
-| LINEPAY_CHANNEL_ID | 字串 | '' | LINE Pay 串接所需的 channel id |
-| LINEPAY_CHANNEL_KEY | 字串 | '' | LINE Pay 串接所需的 channel key |
-| LINEPAY_CLIENT_MODE | 字串 | 'development' | 串接 LINE Pay 的模式，數值有 `development` 和 `production` |
-| PUBSUB_LINEPAY_WEBHOOK_TOPIC_NAME | 字串 | 'linepay-webhook-dev' | LINE Pay 付款資訊寫入 PubSub 的主題名稱 |
-| SEARCH_URL | 字串 | 'search-url/search' | 搜尋頁面url |
-| MEMBER_ARTICLE_HISTORY_MAX_AGE | 字串 | '30' | 會員訂閱前閱覽紀錄有效期限，以分鐘為單位 |
-| DONATION_PAGE_URL | 字串 | undefined | 捐款頁網址（目前捐款頁為外部頁面，使用 `/donate` 作為 proxy ） |
+
+| 變數名稱                          | 資料型態         | 初始值                                       | 變數說明                                                                      |
+| --------------------------------- | ---------------- | -------------------------------------------- | ----------------------------------------------------------------------------- | --- |
+| ENV                               | 字串             | 'local'                                      | 系統環境，目前已知有；`local`、`dev`、`staging`、`production` 和 `lighthouse` |
+| REDIS_READ_HOST                   | 字串             | 'redis-read-host'                            | 讀取用的 Redis hostname or ip                                                 |
+| REDIS_WRITE_HOST                  | 字串             | 'redis-write-host'                           | 寫入用的 Redis hostname or ip                                                 |
+| REDIS_AUTH                        | 字串             | 'redis-auth'                                 | Reids 驗證用資訊                                                              |
+| NEWEBPAY_KEY                      | 長度為 32 的字串 | 'newebpay-key'                               | 藍新支付 API key (Premium 訂閱)                                               |
+| NEWEBPAY_IV                       | 長度為 16 的字串 | 'newebpay-iv'                                | 藍新支付 API iv (Premium 訂閱)                                                |
+| NEWEBPAY_MEMBERSHIP_API_URL       | 字串             | 'https://ccore.newebpay.com/MPG/mpg_gateway' | 藍新支付 API URL (Premium 訂閱)                                               |
+| NEWEBPAY_PAPERMAG_KEY             | 字串             | 'newebpay-papermag-key'                      | 藍新支付 API key (紙本雜誌)                                                   |
+| NEWEBPAY_PAPERMAG_IV              | 字串             | 'newebpay-papermag-iv'                       | 藍新支付 API iv (紙本雜誌)                                                    |
+| NEWEBPAY_PAPERMAG_API_URL         | 字串             | 'https://ccore.newebpay.com/MPG/mpg_gateway' | 藍新支付 API URL (紙本雜誌)                                                   |
+| ISRAFEL_ORIGIN                    | 字串             | 'israfel-origin'                             | Israfel URL                                                                   |
+| API_HOST                          | 字串             | 'api-host'                                   | API GATEWAY URL                                                               |
+| API_HOST_MEMBERSHIP_GATEWAY       | 字串             | 'api-host-membership-gateway'                | API GATEWAY URL                                                               |
+| API_MEMBER_SUBSCRIPTION_GATEWAY   | 字串             | 'api-member-subscription-gateway'            | API GATEWAY URL                                                               |
+| IS_AD_DISABLE                     | 布林值           | false                                        |                                                                               |     |
+| PREMIUM_AD_FEATURE_TOGGLE         | 布林值           | false                                        | 用 'on' 啟用的數值 ...                                                        |
+| ENABLE_CLOUD_LOGGING              | 布林值           | false                                        | 開啟 gcloud/logging 行為                                                      |
+| LINEPAY_CHANNEL_ID                | 字串             | ''                                           | LINE Pay 串接所需的 channel id                                                |
+| LINEPAY_CHANNEL_KEY               | 字串             | ''                                           | LINE Pay 串接所需的 channel key                                               |
+| LINEPAY_CLIENT_MODE               | 字串             | 'development'                                | 串接 LINE Pay 的模式，數值有 `development` 和 `production`                    |
+| PUBSUB_LINEPAY_WEBHOOK_TOPIC_NAME | 字串             | 'linepay-webhook-dev'                        | LINE Pay 付款資訊寫入 PubSub 的主題名稱                                       |
+| SEARCH_URL                        | 字串             | 'search-url/search'                          | 搜尋頁面 url                                                                  |
+| MEMBER_ARTICLE_HISTORY_MAX_AGE    | 字串             | '30'                                         | 會員訂閱前閱覽紀錄有效期限，以分鐘為單位                                      |
+| DONATION_PAGE_URL                 | 字串             | undefined                                    | 捐款頁網址（目前捐款頁為外部頁面，使用 `/donate` 作為 proxy ）                |
+| WARN_LIFE_FEATURE_TOGGLE          | 布林值           | false                                        | 用 'on' 啟用的數值 ...                                                        |
 
 ## Feature Toggle
-| 變數名稱 | 資料型態 | 初始值 | 變數說明 |
-| --- | --- | --- | --- |
-| EMAIL_VERIFY_FEATURE_TOGGLE | 'on', 'off' | 'off' | |
-| NO_AD_FEATURE_TOGGLE | 'on', 'off' | 'off' | |
-| TOPIC_LIST_FEATURE_TOGGLE | 'on', 'off' | 'off' | |
-| SUBSCRIPTION_PRICE_FEATURE_TOGGLE | 'on', 'off' | 'off' | |
-| HEADER_EXTERNALS_FEATURE_TOGGLE | 'on', 'off' | 'off' | |
-| LINEPAY_PAYMENT_UI_TOGGLE | 'on', 'off' | 'off' | 確認付款頁 LINEPay 支付功能啟用開關 |
-| RECORD_MEMBER_ARTICLE_HISTORY_FEATURE_TOGGLE | 'on', 'off' | 'off' | 記錄會員訂閱前閱覽紀錄 |
-| DONATE_FEATURE_TOGGLE | 'on', 'off' | 'off' | 捐款功能啟用開關 |
+
+| 變數名稱                                     | 資料型態    | 初始值 | 變數說明                            |
+| -------------------------------------------- | ----------- | ------ | ----------------------------------- |
+| EMAIL_VERIFY_FEATURE_TOGGLE                  | 'on', 'off' | 'off'  |                                     |
+| NO_AD_FEATURE_TOGGLE                         | 'on', 'off' | 'off'  |                                     |
+| TOPIC_LIST_FEATURE_TOGGLE                    | 'on', 'off' | 'off'  |                                     |
+| SUBSCRIPTION_PRICE_FEATURE_TOGGLE            | 'on', 'off' | 'off'  |                                     |
+| HEADER_EXTERNALS_FEATURE_TOGGLE              | 'on', 'off' | 'off'  |                                     |
+| LINEPAY_PAYMENT_UI_TOGGLE                    | 'on', 'off' | 'off'  | 確認付款頁 LINEPay 支付功能啟用開關 |
+| RECORD_MEMBER_ARTICLE_HISTORY_FEATURE_TOGGLE | 'on', 'off' | 'off'  | 記錄會員訂閱前閱覽紀錄              |
+| DONATE_FEATURE_TOGGLE                        | 'on', 'off' | 'off'  | 捐款功能啟用開關                    |
 
 ※ 在執行指令時，使用 `key=value` 的前綴來執行，例如：`ENV=dev yarn dev`，即可設定執行時的環境變數。

--- a/components/ContainerList.vue
+++ b/components/ContainerList.vue
@@ -129,7 +129,7 @@ export default {
     listItemsInLoadmorePage() {
       if (
         this.$config.warmlifeFeatureToggle &&
-        this.$route.params?.name === 'warnlife'
+        this.$route.params?.name === 'warmlife'
       ) {
         return removeArticleWithExternalLink(this.listItemsAfterRedirect).slice(
           this.maxResults,

--- a/components/ContainerList.vue
+++ b/components/ContainerList.vue
@@ -127,6 +127,15 @@ export default {
       )
     },
     listItemsInLoadmorePage() {
+      if (
+        this.$config.warmlifeFeatureToggle &&
+        this.$route.params?.name === 'warnlife'
+      ) {
+        return removeArticleWithExternalLink(this.listItemsAfterRedirect).slice(
+          this.maxResults,
+          this.nowPage * this.maxResults
+        )
+      }
       return removeArticleWithExternalLink(this.listItemsAfterRedirect).slice(
         this.maxResults,
         Infinity

--- a/components/UiHeaderNavSection.vue
+++ b/components/UiHeaderNavSection.vue
@@ -88,9 +88,18 @@ export default {
   },
   computed: {
     displayPartners() {
-      return (
-        this.partners.filter((partner) => partner.name === 'healthnews') ?? []
-      )
+      if (this.$config.warmlifeFeatureToggle) {
+        return [
+          {
+            name: 'warnlife',
+            display: '生活暖流',
+          },
+        ]
+      } else {
+        return (
+          this.partners.filter((partner) => partner.name === 'healthnews') ?? []
+        )
+      }
     },
   },
   methods: {

--- a/components/UiHeaderNavSection.vue
+++ b/components/UiHeaderNavSection.vue
@@ -91,7 +91,7 @@ export default {
       if (this.$config.warmlifeFeatureToggle) {
         return [
           {
-            name: 'warnlife',
+            name: 'warmlife',
             display: '生活暖流',
           },
         ]

--- a/configs/config.js
+++ b/configs/config.js
@@ -36,6 +36,8 @@ const LINEPAY_CLIENT_MODE = ['development', 'production'].includes(
   : 'development'
 const SEARCH_URL = process.env.SEARCH_URL || 'search-url/search'
 const DONATION_PAGE_URL = process.env.DONATION_PAGE_URL
+const WARN_LIFE_FEATURE_TOGGLE =
+  process.env.WARN_LIFE_FEATURE_TOGGLE === 'on' || false
 
 // The following variables are given values according to different `ENV`
 let API_HOST = ''
@@ -174,4 +176,5 @@ export {
   SEARCH_URL,
   PUBSUB_LINEPAY_WEBHOOK_TOPIC_NAME,
   DONATION_PAGE_URL,
+  WARN_LIFE_FEATURE_TOGGLE,
 }

--- a/configs/config.js
+++ b/configs/config.js
@@ -36,8 +36,8 @@ const LINEPAY_CLIENT_MODE = ['development', 'production'].includes(
   : 'development'
 const SEARCH_URL = process.env.SEARCH_URL || 'search-url/search'
 const DONATION_PAGE_URL = process.env.DONATION_PAGE_URL
-const WARN_LIFE_FEATURE_TOGGLE =
-  process.env.WARN_LIFE_FEATURE_TOGGLE === 'on' || false
+const WARM_LIFE_FEATURE_TOGGLE =
+  process.env.WARM_LIFE_FEATURE_TOGGLE === 'on' || false
 
 // The following variables are given values according to different `ENV`
 let API_HOST = ''
@@ -176,5 +176,5 @@ export {
   SEARCH_URL,
   PUBSUB_LINEPAY_WEBHOOK_TOPIC_NAME,
   DONATION_PAGE_URL,
-  WARN_LIFE_FEATURE_TOGGLE,
+  WARM_LIFE_FEATURE_TOGGLE,
 }

--- a/configs/config.js
+++ b/configs/config.js
@@ -39,6 +39,8 @@ const DONATION_PAGE_URL = process.env.DONATION_PAGE_URL
 const WARN_LIFE_FEATURE_TOGGLE =
   process.env.WARN_LIFE_FEATURE_TOGGLE === 'on' || false
 
+console.log(45666, process.env.WARN_LIFE_FEATURE_TOGGLE === 'on')
+
 // The following variables are given values according to different `ENV`
 let API_HOST = ''
 let API_HOST_MEMBERSHIP_GATEWAY = ''

--- a/configs/config.js
+++ b/configs/config.js
@@ -39,8 +39,6 @@ const DONATION_PAGE_URL = process.env.DONATION_PAGE_URL
 const WARN_LIFE_FEATURE_TOGGLE =
   process.env.WARN_LIFE_FEATURE_TOGGLE === 'on' || false
 
-console.log(45666, process.env.WARN_LIFE_FEATURE_TOGGLE === 'on')
-
 // The following variables are given values according to different `ENV`
 let API_HOST = ''
 let API_HOST_MEMBERSHIP_GATEWAY = ''

--- a/mixins/fetch-list-and-loadmore.js
+++ b/mixins/fetch-list-and-loadmore.js
@@ -11,6 +11,9 @@ export default function fetchListAndLoadmore({
   getListTotal = function (response = {}) {
     return response.meta?.total ?? 0
   },
+  getPage = function (response = {}) {
+    return response.meta?.total ?? 0
+  },
   transformListItemContent,
 } = {}) {
   return {
@@ -33,10 +36,12 @@ export default function fetchListAndLoadmore({
           }
         )
       },
+      nowPage() {
+        return this.$data.$_fetchListAndLoadmore_list.page
+      },
       shouldLoadmore() {
         return this.$data.$_fetchListAndLoadmore_list.maxPage >= 2
       },
-
       maxResults() {
         if (!maxResults) {
           throw new TypeError(
@@ -92,10 +97,13 @@ export default function fetchListAndLoadmore({
         const brief =
           (typeof item.brief === 'string' ? item.brief : item.brief?.html) ?? ''
 
+        // for warnlife, just for prod
+        item.slug = item.slug || item.name
         return {
-          id: item.id,
+          id: item.id || item._id,
           href: getStoryPath(item),
-          imgSrc: item.heroImage?.image?.resizedTargets?.mobile?.url,
+          imgSrc:
+            item.heroImage?.image?.resizedTargets?.mobile?.url || item.thumb,
           imgText: section.title ?? '',
           imgTextBackgroundColor: section.name && getSectionColor(section.name),
           infoTitle: item.title ?? '',
@@ -108,7 +116,6 @@ export default function fetchListAndLoadmore({
       async infiniteHandler(state) {
         try {
           await this.$_fetchListAndLoadmore_loadList()
-
           if (
             this.$data.$_fetchListAndLoadmore_list.page >=
             this.$data.$_fetchListAndLoadmore_list.maxPage

--- a/mixins/fetch-list-and-loadmore.js
+++ b/mixins/fetch-list-and-loadmore.js
@@ -97,7 +97,7 @@ export default function fetchListAndLoadmore({
         const brief =
           (typeof item.brief === 'string' ? item.brief : item.brief?.html) ?? ''
 
-        // for warnlife, just for prod
+        // for warmlife, just for prod
         item.slug = item.slug || item.name
         return {
           id: item.id || item._id,

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -621,6 +621,7 @@ module.exports = {
     recordMemberArticleMaxAge:
       parseInt(process.env.MEMBER_ARTICLE_HISTORY_MAX_AGE) || 30,
     donateFeatureToggle: process.env.DONATE_FEATURE_TOGGLE === 'on',
+    warmlifeFeatureToggle: process.env.WARN_LIFE_FEATURE_TOGGLE === 'on',
   },
 
   env: {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -621,7 +621,7 @@ module.exports = {
     recordMemberArticleMaxAge:
       parseInt(process.env.MEMBER_ARTICLE_HISTORY_MAX_AGE) || 30,
     donateFeatureToggle: process.env.DONATE_FEATURE_TOGGLE === 'on',
-    warmlifeFeatureToggle: process.env.WARN_LIFE_FEATURE_TOGGLE === 'on',
+    warmlifeFeatureToggle: process.env.WARM_LIFE_FEATURE_TOGGLE === 'on',
   },
 
   env: {

--- a/pages/externals/_name.vue
+++ b/pages/externals/_name.vue
@@ -16,6 +16,7 @@
 <script>
 import { mapGetters } from 'vuex'
 
+import axios from 'axios'
 import ContainerList from '~/components/ContainerList.vue'
 import ContainerFullScreenAds from '~/components/ContainerFullScreenAds.vue'
 import UiStickyAd from '~/components/UiStickyAd.vue'
@@ -42,6 +43,12 @@ export default {
     ...mapGetters({
       partners: 'partners/displayedPartners',
     }),
+    isWarnLife() {
+      return (
+        this.$route.params.name === 'warnlife' &&
+        this.$config.warmlifeFeatureToggle
+      )
+    },
     partnerName() {
       return this.$route.params.name
     },
@@ -56,6 +63,7 @@ export default {
       return this.partnerData.id ?? ''
     },
     partnerTitle() {
+      if (this.isWarnLife) return '生活暖流'
       return this.partnerData.display ?? ''
     },
   },
@@ -70,6 +78,24 @@ export default {
   },
   methods: {
     async fetchList(page) {
+      if (this.isWarnLife) {
+        try {
+          const { data } = await axios(
+            'https://storage.googleapis.com/statics.mirrormedia.mg/json/life_feed.json'
+          )
+          return {
+            items: data._items,
+            links: data._links,
+            meta: {
+              ...data._meta,
+              total: data._items?.length || 0,
+            },
+          }
+        } catch (error) {
+          console.log(error)
+          return []
+        }
+      }
       return await this.$fetchExternals({
         maxResults: 9,
         sort: '-publishedDate',

--- a/pages/externals/_name.vue
+++ b/pages/externals/_name.vue
@@ -43,9 +43,9 @@ export default {
     ...mapGetters({
       partners: 'partners/displayedPartners',
     }),
-    isWarnLife() {
+    isWarmLife() {
       return (
-        this.$route.params.name === 'warnlife' &&
+        this.$route.params.name === 'warmlife' &&
         this.$config.warmlifeFeatureToggle
       )
     },
@@ -63,7 +63,7 @@ export default {
       return this.partnerData.id ?? ''
     },
     partnerTitle() {
-      if (this.isWarnLife) return '生活暖流'
+      if (this.isWarmLife) return '生活暖流'
       return this.partnerData.display ?? ''
     },
   },
@@ -78,7 +78,7 @@ export default {
   },
   methods: {
     async fetchList(page) {
-      if (this.isWarnLife) {
+      if (this.isWarmLife) {
         try {
           const { data } = await axios(
             'https://storage.googleapis.com/statics.mirrormedia.mg/json/life_feed.json'

--- a/plugins/requests/index.js
+++ b/plugins/requests/index.js
@@ -240,9 +240,9 @@ export default (context, inject) => {
 
   inject('fetchEvent', (params) => fetchApiData(`/event${buildParams(params)}`))
 
-  inject('fetchExternals', (params) =>
-    fetchApiData(`/externals${buildParams(params)}`)
-  )
+  inject('fetchExternals', (params) => {
+    return fetchApiData(`/externals${buildParams(params)}`)
+  })
 
   inject('fetchImages', (params) =>
     fetchApiData(`/images${buildParams(params)}`)

--- a/store/partners.js
+++ b/store/partners.js
@@ -1,11 +1,11 @@
 export const state = () => ({
   data: {},
-  isWarnlifeFeatureToggleOn: false,
+  isWarmlifeFeatureToggleOn: false,
 })
 
 export const getters = {
   displayedPartners(state) {
-    if (state.isWarnlifeFeatureToggleOn) {
+    if (state.isWarmlifeFeatureToggleOn) {
       return state.data.items
     }
     return state.data.items?.filter((partner) => partner.public) ?? []
@@ -16,8 +16,8 @@ export const mutations = {
   setPartnersData(state, data) {
     state.data = data
   },
-  setIsWarnlifeFeaturToggleOn(state, isWarnlifeFeatureToggleOn) {
-    state.isWarnlifeFeatureToggleOn = isWarnlifeFeatureToggleOn
+  setIsWarmlifeFeaturToggleOn(state, isWarmlifeFeatureToggleOn) {
+    state.isWarmlifeFeatureToggleOn = isWarmlifeFeatureToggleOn
   },
 }
 
@@ -28,6 +28,6 @@ export const actions = {
       (await this.$fetchPartners({ maxResults: 25, page: 1 })) || {}
 
     commit('setPartnersData', response)
-    commit('setIsWarnlifeFeaturToggleOn', featureToggle)
+    commit('setIsWarmlifeFeaturToggleOn', featureToggle)
   },
 }

--- a/store/partners.js
+++ b/store/partners.js
@@ -1,9 +1,13 @@
 export const state = () => ({
   data: {},
+  isWarnlifeFeatureToggleOn: false,
 })
 
 export const getters = {
   displayedPartners(state) {
+    if (state.isWarnlifeFeatureToggleOn) {
+      return state.data.items
+    }
     return state.data.items?.filter((partner) => partner.public) ?? []
   },
 }
@@ -12,13 +16,18 @@ export const mutations = {
   setPartnersData(state, data) {
     state.data = data
   },
+  setIsWarnlifeFeaturToggleOn(state, isWarnlifeFeatureToggleOn) {
+    state.isWarnlifeFeatureToggleOn = isWarnlifeFeatureToggleOn
+  },
 }
 
 export const actions = {
   async fetchPartnersData({ commit }) {
+    const featureToggle = this.app.$config.warmlifeFeatureToggle
     const response =
       (await this.$fetchPartners({ maxResults: 25, page: 1 })) || {}
 
     commit('setPartnersData', response)
+    commit('setIsWarnlifeFeaturToggleOn', featureToggle)
   },
 }


### PR DESCRIPTION
### 描述
- 新增 feature toggle `WARN_LIFE_FEATURE_TOGGLE`。
- 將 header 的「健康生活網」改成「生活暖流」，並且連結至 `/externals/warnlife`。
- 原本如果沒有勾選公開的 partner 就不會顯示，變成不管有沒有勾選都顯示。（可參考 `/externals/ebc`）
- `/externals/warnlife` 和其他 `/externals/_name` 共用檔案，並將 fetch 回來的 JSON 資料名稱額外處理，例如 `meta.total` 是抓資料庫全部資料，但需求方只想顯示前一百則，因此改成直接抓 items 長度。
- 原本的 loadmore 邏輯是會一次抓 9 則，因此 `listItemsInLoadmorePage` 顯示第二頁後（因為第一頁後要額外放廣告）所有資料，但因為生活暖流 JSON 一次會將所有資料抓回，因此改成拿數據，並顯示第二頁到 `this.nowPage * this.maxResults` 的資料。

### 參考資料
- [Asana 卡片](https://app.asana.com/0/1199408264065173/1204222259856499/f)