### PR TITLE
refactor(parners): all situation filter public parners

### DIFF
--- a/store/partners.js
+++ b/store/partners.js
@@ -5,9 +5,6 @@ export const state = () => ({
 
 export const getters = {
   displayedPartners(state) {
-    if (state.isWarmlifeFeatureToggleOn) {
-      return state.data.items
-    }
     return state.data.items?.filter((partner) => partner.public) ?? []
   },
 }


### PR DESCRIPTION
### 描述
- 原本需求：`parners` 的 `public` 欄位會用來判斷「是否為生活暖流」，因此不管是否有勾選都應於前台顯示。
- 需求調整：「是否為生活暖流」改為由 parner slug 判斷，因此若沒勾選 `public`，就於前台顯示。

### 參考資料
- [Asana 卡片](https://app.asana.com/0/1204256111880101/1204256111880110/f)