### PR TITLE
feat(profile/purchase): get one-time purchase post name from keystone 6

### DIFF
--- a/apollo/queries/postsInKeystone6.gql
+++ b/apollo/queries/postsInKeystone6.gql
@@ -1,0 +1,7 @@
+query postOnlyId($id: [ID!]) {
+  posts(where: { id: { in: $id } }) {
+    id
+    title
+    slug
+  }
+}

--- a/configs/config.js
+++ b/configs/config.js
@@ -52,7 +52,7 @@ let SALEOR_HOST = ''
 let NEWEBPAY_MEMBERSHIP_API_URL = ''
 let NEWEBPAY_PAPERMAG_API_URL = ''
 let PUBSUB_LINEPAY_WEBHOOK_TOPIC_NAME = ''
-
+let WEEKLY_API_SERVER_ORIGIN = ''
 switch (ENV) {
   case 'prod':
     API_HOST = 'tr-projects-rest'
@@ -73,6 +73,7 @@ switch (ENV) {
       'https://core.newebpay.com/MPG/mpg_gateway'
     PUBSUB_LINEPAY_WEBHOOK_TOPIC_NAME =
       process.env.PUBSUB_LINEPAY_WEBHOOK_TOPIC_NAME || 'linepay-webhook'
+    WEEKLY_API_SERVER_ORIGIN = ''
     break
   case 'staging':
     API_HOST = 'tr-projects-rest'
@@ -93,6 +94,7 @@ switch (ENV) {
       'https://ccore.newebpay.com/MPG/mpg_gateway'
     PUBSUB_LINEPAY_WEBHOOK_TOPIC_NAME =
       process.env.PUBSUB_LINEPAY_WEBHOOK_TOPIC_NAME || 'linepay-webhook-staging'
+    WEEKLY_API_SERVER_ORIGIN = ''
     break
   case 'dev':
     API_HOST = 'rest-service'
@@ -112,6 +114,8 @@ switch (ENV) {
       'https://ccore.newebpay.com/MPG/mpg_gateway'
     PUBSUB_LINEPAY_WEBHOOK_TOPIC_NAME =
       process.env.PUBSUB_LINEPAY_WEBHOOK_TOPIC_NAME || 'linepay-webhook-dev'
+    WEEKLY_API_SERVER_ORIGIN =
+      'adam-weekly-api-server-dev-ufaummkd5q-de.a.run.app'
     break
   default:
     API_HOST = process.env.API_HOST || 'api-host'
@@ -134,6 +138,8 @@ switch (ENV) {
       'https://ccore.newebpay.com/MPG/mpg_gateway'
     PUBSUB_LINEPAY_WEBHOOK_TOPIC_NAME =
       process.env.PUBSUB_LINEPAY_WEBHOOK_TOPIC_NAME || 'linepay-webhook-dev'
+    WEEKLY_API_SERVER_ORIGIN =
+      'adam-weekly-api-server-dev-ufaummkd5q-de.a.run.app'
 }
 
 export {
@@ -177,4 +183,5 @@ export {
   PUBSUB_LINEPAY_WEBHOOK_TOPIC_NAME,
   DONATION_PAGE_URL,
   WARM_LIFE_FEATURE_TOGGLE,
+  WEEKLY_API_SERVER_ORIGIN,
 }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -622,6 +622,8 @@ module.exports = {
       parseInt(process.env.MEMBER_ARTICLE_HISTORY_MAX_AGE) || 30,
     donateFeatureToggle: process.env.DONATE_FEATURE_TOGGLE === 'on',
     warmlifeFeatureToggle: process.env.WARM_LIFE_FEATURE_TOGGLE === 'on',
+    purchaseOneTimeFeatureToggle:
+      process.env.PURCHASE_ONE_TIME_FEATURE_TOGGLE === 'on',
   },
 
   env: {

--- a/pages/profile/purchase.vue
+++ b/pages/profile/purchase.vue
@@ -124,6 +124,11 @@ export default {
         if (this.isBasic) {
           // fetch onetime subscription list
           this.postList = await this.$getMemberOneTimeSubscriptions({})
+
+          if (this.$config.purchaseOneTimeFeatureToggle) {
+            const resultOfK6 = await this.$getMemberOneTimeSubscriptionsK6({})
+            this.postList = [...this.postList, ...resultOfK6]
+          }
         }
 
         this.payRecords = await this.$getSubscriptionPayments({})

--- a/plugins/requests/index.js
+++ b/plugins/requests/index.js
@@ -12,6 +12,7 @@ import {
   getMemberType,
   getPaymentDataOfSubscription,
   getMemberOneTimeSubscriptions,
+  getMemberOneTimeSubscriptionsK6,
   getSubscriptionPayments,
   getMemberShipStatus,
   getPremiumMemberSubscriptionInfo,
@@ -385,6 +386,9 @@ export default (context, inject) => {
   })
   inject('getMemberOneTimeSubscriptions', async (gateWayPayload) => {
     return await getMemberOneTimeSubscriptions(context, gateWayPayload)
+  })
+  inject('getMemberOneTimeSubscriptionsK6', async (gateWayPayload) => {
+    return await getMemberOneTimeSubscriptionsK6(context, gateWayPayload)
   })
   inject('getSubscriptionPayments', async (gateWayPayload) => {
     return await getSubscriptionPayments(context, gateWayPayload)


### PR DESCRIPTION
## Notable change
1. 新增feature toggle `purchaseOneTimeFeatureToggle`
2. 依據feature toggle，決定profile/prochase頁中，是否單篇訂閱文章內容。如果為真，則會抓取k3與k6的文章。如果為假，則僅抓取k3的內容。
3. 針對抓取k6內容，另外撰寫對應的utils函式，以及apollo query