### PR TITLE
feat(header): fetch new header data, adjust related component

### DIFF
--- a/components/ContainerHeader.vue
+++ b/components/ContainerHeader.vue
@@ -59,8 +59,9 @@
 
     <nav class="header-nav">
       <UiHeaderNavSection
-        :sections="sections"
+        :sections="displayedHeaderData"
         :currentSectionName="sectionName"
+        :currentCategoryName="currentCategoryName"
         :partners="partners"
         @sendGa="handleSendGa"
       />
@@ -111,6 +112,329 @@ import {
 
 let headerHight = 0
 
+const DEFAULT_NORMAL_SECTIONS_DATA = [
+  {
+    order: 1,
+    type: 'section',
+    slug: 'member',
+    name: '會員專區',
+    categories: [
+      {
+        id: '1',
+        slug: 'food',
+        name: '美食焦點',
+        isMemberOnly: true,
+      },
+      {
+        id: '2',
+        slug: 'traveltaiwan',
+        name: '旅行台灣',
+        isMemberOnly: true,
+      },
+      {
+        id: '7',
+        slug: 'seetheworld',
+        name: '看見世界',
+        isMemberOnly: true,
+      },
+      {
+        id: '8',
+        slug: 'kitchenplay',
+        name: '廚房密技',
+        isMemberOnly: true,
+      },
+      {
+        id: '19',
+        slug: 'money',
+        name: '理財',
+        isMemberOnly: true,
+      },
+      {
+        id: '25',
+        slug: 'celebrity',
+        name: '鏡大咖',
+        isMemberOnly: true,
+      },
+      {
+        id: '27',
+        slug: 'column',
+        name: '影劇專欄',
+        isMemberOnly: true,
+      },
+      {
+        id: '35',
+        slug: 'wine',
+        name: '好酒情報',
+        isMemberOnly: true,
+      },
+      {
+        id: '49',
+        slug: 'somebody',
+        name: '一鏡到底',
+        isMemberOnly: true,
+      },
+      {
+        id: '50',
+        slug: 'world',
+        name: '鏡相人間',
+        isMemberOnly: true,
+      },
+      {
+        id: '51',
+        slug: 'truth',
+        name: '心內話',
+        isMemberOnly: true,
+      },
+      {
+        id: '52',
+        slug: 'mogul',
+        name: '財經人物',
+        isMemberOnly: true,
+      },
+      {
+        id: '94',
+        slug: 'timesquare',
+        name: '時代現場',
+        isMemberOnly: true,
+      },
+      {
+        id: '112',
+        slug: 'mg',
+        name: '完整全文',
+        isMemberOnly: false,
+      },
+      {
+        id: '113',
+        slug: 'dig',
+        name: '新聞深探',
+        isMemberOnly: true,
+      },
+    ],
+  },
+  {
+    order: 2,
+    type: 'category',
+    slug: 'news',
+    name: '焦點',
+    isMemberOnly: false,
+    sections: ['news'],
+  },
+  {
+    order: 3,
+    type: 'section',
+    slug: 'entertainment',
+    name: '娛樂',
+    categories: [
+      {
+        id: '24',
+        slug: 'latestnews',
+        name: '娛樂頭條',
+        isMemberOnly: false,
+      },
+      {
+        id: '36',
+        slug: 'insight',
+        name: '娛樂透視',
+        isMemberOnly: false,
+      },
+      {
+        id: '48',
+        slug: 'comic',
+        name: '動漫遊戲',
+        isMemberOnly: false,
+      },
+      {
+        id: '61',
+        slug: 'rookie',
+        name: '試鏡間',
+        isMemberOnly: false,
+      },
+      {
+        id: '62',
+        slug: 'fashion',
+        name: '穿衣鏡',
+        isMemberOnly: false,
+      },
+      {
+        id: '63',
+        slug: 'madam',
+        name: '蘭蘭夫人',
+        isMemberOnly: false,
+      },
+      {
+        id: '64',
+        slug: 'superstar',
+        name: '我眼中的大明星',
+        isMemberOnly: false,
+      },
+    ],
+  },
+  {
+    order: 4,
+    type: 'category',
+    slug: 'political',
+    name: '政治',
+    isMemberOnly: false,
+    sections: ['news'],
+  },
+  {
+    order: 5,
+    type: 'category',
+    slug: 'business',
+    name: '財經',
+    isMemberOnly: false,
+    sections: ['businessmoney'],
+  },
+  {
+    order: 6,
+    type: 'category',
+    slug: 'city-news',
+    name: '社會',
+    isMemberOnly: false,
+    sections: ['news'],
+  },
+  {
+    order: 7,
+    type: 'section',
+    slug: 'life',
+    name: '生活',
+    categories: [
+      {
+        id: '46',
+        slug: 'life',
+        name: '萬象',
+        isMemberOnly: false,
+      },
+      {
+        id: '74',
+        slug: 'knowledgeprogram',
+        name: '知識好好玩',
+        isMemberOnly: false,
+      },
+      {
+        id: '75',
+        slug: 'bookreview',
+        name: '書評',
+        isMemberOnly: false,
+      },
+      {
+        id: '76',
+        slug: 'culture-column',
+        name: '專欄',
+        isMemberOnly: false,
+      },
+      {
+        id: '77',
+        slug: 'poem',
+        name: '詩',
+        isMemberOnly: false,
+      },
+      {
+        id: '95',
+        slug: 'booksummary',
+        name: '鏡書摘',
+        isMemberOnly: false,
+      },
+      {
+        id: '109',
+        slug: 'vioce',
+        name: '好聽人物',
+        isMemberOnly: false,
+      },
+    ],
+  },
+  {
+    order: 8,
+    type: 'category',
+    slug: 'global',
+    name: '國際要聞',
+    isMemberOnly: false,
+    sections: ['news', 'international'],
+  },
+  {
+    order: 9,
+    type: 'section',
+    slug: 'carandwatch',
+    name: '汽車鐘錶',
+    categories: [
+      {
+        id: '11',
+        slug: 'watchfocus',
+        name: '錶壇焦點',
+        isMemberOnly: false,
+      },
+      {
+        id: '12',
+        slug: 'watchfeature',
+        name: '鐘錶專題',
+        isMemberOnly: false,
+      },
+      {
+        id: '15',
+        slug: 'blog',
+        name: '編輯幕後',
+        isMemberOnly: false,
+      },
+      {
+        id: '56',
+        slug: 'car_focus',
+        name: '車壇焦點',
+        isMemberOnly: false,
+      },
+      {
+        id: '57',
+        slug: 'car_features',
+        name: '鏡車專題',
+        isMemberOnly: false,
+      },
+      {
+        id: '58',
+        slug: 'test_drives',
+        name: '靚俥試駕',
+        isMemberOnly: false,
+      },
+      {
+        id: '59',
+        slug: 'pit_zone',
+        name: '鏡車經',
+        isMemberOnly: false,
+      },
+      {
+        id: '107',
+        slug: 'newwatches2021',
+        name: '新錶2021',
+        isMemberOnly: false,
+      },
+      {
+        id: '111',
+        slug: 'luxury',
+        name: '奢華誌',
+        isMemberOnly: false,
+      },
+      {
+        id: '114',
+        slug: 'newwatches2022',
+        name: '新錶2022',
+        isMemberOnly: false,
+      },
+      {
+        id: '115',
+        slug: 'newwatches2023',
+        name: '新錶2023',
+        isMemberOnly: false,
+      },
+    ],
+  },
+  {
+    order: 10,
+    type: 'category',
+    slug: 'mafalda-1',
+    name: '瑪法達',
+    isMemberOnly: false,
+    sections: [],
+  },
+]
+
 export default {
   name: 'ContainerHeader',
   components: {
@@ -130,13 +454,26 @@ export default {
       type: String,
       default: undefined,
     },
+    currentCategoryName: {
+      type: String,
+      default: undefined,
+    },
+  },
+  async fetch() {
+    try {
+      const res = await this.$fetchHeadersNew()
+      this.headerData = res.headers
+    } catch (error) {
+      console.error(error)
+      this.headerData = []
+    }
   },
 
   data() {
     return {
       shouldFixHeader: false,
       SITE_TITLE,
-
+      headerData: [],
       eventLogo: {},
       now: new Date(),
       intervalIdOfUpdateNow: undefined,
@@ -159,7 +496,131 @@ export default {
       topics: 'topics/displayedTopics',
       isDesktopWidth: 'viewport/isViewportWidthUpXl',
     }),
+    displayedHeaderData() {
+      const formatSectionItem = (section) => {
+        const sectionWithMagazine = insertMagazineIntoSectionMember(section)
+        const sectionsAndCategoriesWithHref =
+          getSectionAndCategoryHref(sectionWithMagazine)
+        return sectionsAndCategoriesWithHref
 
+        function insertMagazineIntoSectionMember(section) {
+          if (section.slug === 'member') {
+            return {
+              ...section,
+              categories: [
+                {
+                  id: '7a7482edb739242537f11e24760d2c79', // hash for ensure it is unique from other category, no other usage.
+                  slug: 'magazine',
+                  name: '動態雜誌',
+                  isMemberOnly: false,
+                },
+                ...section.categories,
+              ],
+            }
+          } else if (section.slug === 'life') {
+            return {
+              ...section,
+              categories: [
+                ...section.categories,
+                {
+                  id: '306dac073da6dc1ddb4e34c228035915', // hash for ensure it is unique from other category, no other usage.
+                  slug: 'warmlife',
+                  name: '暖流',
+                  isMemberOnly: false,
+                },
+              ],
+            }
+          }
+          return { ...section }
+        }
+
+        function getSectionAndCategoryHref(section) {
+          return {
+            ...section,
+            href: getSectionHref(section.slug),
+            categories: getCategoryInSectionWithHref(section),
+          }
+
+          function getSectionHref(sectionSlug) {
+            if (sectionSlug === 'member') {
+              return `/premiumsection/${sectionSlug}`
+            } else {
+              return `/section/${sectionSlug}`
+            }
+          }
+
+          function getCategoryInSectionWithHref(section) {
+            const { categories = [] } = section
+            return categories.map((category) => {
+              return {
+                ...category,
+                href: getCategoryHref(section.slug, category.slug),
+              }
+            })
+
+            /**
+             * @param {HeadersDataSection['slug']} sectionSlug
+             * @param {import('./nav-sections').CategoryInHeadersDataSection['slug']} categorySlug
+             * @returns {string}
+             */
+            function getCategoryHref(sectionSlug, categorySlug) {
+              if (sectionSlug === 'videohub') {
+                return `/video_category/${categorySlug}`
+              }
+              if (categorySlug === 'magazine') {
+                return '/magazine/'
+              }
+              if (sectionSlug === 'life' && categorySlug === 'warmlife') {
+                return '/externals/warmlife'
+              }
+              return `/category/${categorySlug}`
+            }
+          }
+        }
+      }
+
+      const formatCategoryItem = (category) => {
+        return getSectionAndCategoryHref(category)
+
+        function getSectionAndCategoryHref(section) {
+          return {
+            ...section,
+            href: getCategoryHref(section.sections, section.slug),
+          }
+
+          function getCategoryHref(sections, categorySlug) {
+            if (
+              sections &&
+              sections.length &&
+              sections.some((section) => section === 'videohub')
+            ) {
+              return `/video_category/${categorySlug}`
+            }
+            return `/category/${categorySlug}`
+          }
+        }
+      }
+
+      const formatSections = (sectionsData) => {
+        const _sectionsData =
+          sectionsData && sectionsData.length
+            ? sectionsData
+            : DEFAULT_NORMAL_SECTIONS_DATA
+        const formattedSectionData = _sectionsData.map((item) => {
+          switch (item.type) {
+            case 'section':
+              return formatSectionItem(item)
+            case 'category':
+              return formatCategoryItem(item)
+            default:
+              return null
+          }
+        })
+
+        return formattedSectionData
+      }
+      return formatSections(this.headerData)
+    },
     sectionName() {
       let sectionName
 
@@ -184,7 +645,6 @@ export default {
             }
           } else if (path.startsWith(cat)) {
             const categoryName = removePrefix(path, cat)
-
             sectionName = this.getSectionByCategoryName(categoryName).name
           }
         }

--- a/components/UiHeaderNavSection.vue
+++ b/components/UiHeaderNavSection.vue
@@ -1,10 +1,7 @@
 <template>
   <section class="header-nav-section">
     <div class="container">
-      <div
-        class="section section--home"
-        :class="{ active: isCurrentSection('home') }"
-      >
+      <div class="section section--home">
         <a href="/" @click="emitGa('section home')">
           <h2>首頁</h2>
         </a>
@@ -12,27 +9,24 @@
 
       <div
         v-for="section in sections"
-        :key="section.id"
+        :key="section.order"
         class="section"
         :class="[
-          `section--${section.name}`,
-          { active: isCurrentSection(section.name) },
+          `section--${getSectionSlug(section)}`,
+          { active: isCurrentSection(section) },
         ]"
       >
-        <a
-          :href="`/section/${section.name}`"
-          @click="emitGa(`section ${section.name}`)"
-        >
-          <h2>{{ section.title }}</h2>
+        <a :href="section.href" @click="emitGa(`section ${section.slug}`)">
+          <h2>{{ section.name }}</h2>
         </a>
-        <div class="section__dropdown">
+        <div v-if="section.type === 'section'" class="section__dropdown">
           <a
             v-for="category in section.categories"
             :key="category.id"
-            :href="getCategoryHref(section.name, category.name)"
-            @click="emitGa(`category ${category.name}`)"
+            :href="category.href"
+            @click="emitGa(`category ${category.slug}`)"
           >
-            <h3>{{ category.title }}</h3>
+            <h3>{{ category.name }}</h3>
           </a>
         </div>
       </div>
@@ -80,6 +74,10 @@ export default {
       type: String,
       default: undefined,
     },
+    currentCategoryName: {
+      type: String,
+      default: undefined,
+    },
     partners: {
       type: Array,
       required: true,
@@ -103,8 +101,43 @@ export default {
     },
   },
   methods: {
-    isCurrentSection(sectionName) {
-      return sectionName === this.currentSectionName
+    isCurrentSection(section) {
+      const sectionType = section.type
+      switch (sectionType) {
+        case 'section': {
+          return section.slug === this.currentSectionName
+        }
+        case 'category': {
+          const { path } = this.$route
+          const cat = '/category/'
+          const removePrefix = (str = '', prefix = '') => {
+            return str.slice(prefix.length)
+          }
+          const categoryName = removePrefix(path, cat)
+          const { sections } = section
+          if (path.startsWith(cat)) {
+            return (
+              sections?.[0] === this.currentSectionName &&
+              categoryName === section.slug
+            )
+          } else {
+            return this.currentCategoryName === section.slug
+          }
+        }
+
+        default:
+          return false
+      }
+    },
+    getSectionSlug(section) {
+      switch (section.type) {
+        case 'section':
+          return section.slug
+        case 'category':
+          return section?.sections?.[0]
+        default:
+          return null
+      }
     },
     getCategoryHref(sectionName, categoryName) {
       if (sectionName === 'videohub') {

--- a/pages/story/_slug.vue
+++ b/pages/story/_slug.vue
@@ -15,7 +15,10 @@
       />
 
       <div v-else class="article">
-        <ContainerHeader :currentSectionName="sectionName" />
+        <ContainerHeader
+          :currentSectionName="sectionName"
+          :currentCategoryName="categoryName"
+        />
 
         <div class="story-container">
           <ContainerGptAd
@@ -481,6 +484,9 @@ export default {
     },
     categoryTitle() {
       return this.category.title ?? ''
+    },
+    categoryName() {
+      return this.category.name ?? ''
     },
     doesHaveWineCategory() {
       return doesContainWineName(this.categories)

--- a/plugins/requests/index.js
+++ b/plugins/requests/index.js
@@ -338,6 +338,7 @@ export default (context, inject) => {
 
   inject('fetchPopular', () => fetchGcsData('popularlist'))
 
+  inject('fetchHeadersNew', () => fetchGcsData('headers_new'))
   inject('fetchMemberSections', () => fetchGcsData('member_sections'))
 
   inject('fetchMemberSectionsArticles', () =>

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -24,6 +24,7 @@ $sections-color: (
   culture: #009245,
   carandwatch: #003153,
   external: #30bac8,
+  life: #2ECDA7,
 );
 
 :export {


### PR DESCRIPTION
## Notable Change
1. 新增函式`$fetchHeadersNew`，用於抓取新的header資料。
2. 調整header，使其元件結構符合新的資料結構。
3. 新增section 生活的代表顏色。

reminder: 由於mirror-media-nuxt已經進入maintain mode，新增或改動功能都以最少時間完成為目標，故這次改動的程式碼寫得較為紊亂。